### PR TITLE
Add -usercon option to params to enable rcon support

### DIFF
--- a/CounterStrikeGlobalOffensive/csgoserver
+++ b/CounterStrikeGlobalOffensive/csgoserver
@@ -20,7 +20,7 @@ clientport="27005"
 maxplayers="16"
 ip="0.0.0.0"
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
-parms="-game csgo +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
+parms="-game csgo -usercon +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
 
 #### Advanced Variables ####
 

--- a/CounterStrikeSource/cssserver
+++ b/CounterStrikeSource/cssserver
@@ -20,7 +20,7 @@ clientport="27005"
 maxplayers="16"
 ip="0.0.0.0"
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
-parms="-game cstrike +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
+parms="-game cstrike -usercon +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
 
 #### Advanced Variables ####
 

--- a/DayOfDefeatSource/dodsserver
+++ b/DayOfDefeatSource/dodsserver
@@ -20,7 +20,7 @@ clientport="27005"
 maxplayers="16"
 ip="0.0.0.0"
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
-parms="-game dod +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
+parms="-game dod -usercon +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
 
 #### Advanced Variables ####
 

--- a/HalfLife2Deathmatch/hl2dmserver
+++ b/HalfLife2Deathmatch/hl2dmserver
@@ -20,7 +20,7 @@ clientport="27005"
 maxplayers="16"
 ip="0.0.0.0"
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
-parms="-game hl2mp +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
+parms="-game hl2mp -usercon +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
 
 #### Advanced Variables ####
 

--- a/Left4Dead2/l4d2server
+++ b/Left4Dead2/l4d2server
@@ -20,7 +20,7 @@ clientport="27005"
 maxplayers="16"
 ip="0.0.0.0"
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
-parms="-game left4dead2 +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
+parms="-game left4dead2 -usercon +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
 
 #### Advanced Variables ####
 

--- a/TeamFortress2/tf2server
+++ b/TeamFortress2/tf2server
@@ -20,7 +20,7 @@ clientport="27005"
 maxplayers="16"
 ip="0.0.0.0"
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
-parms="-game tf +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
+parms="-game tf -usercon +map ${defaultmap} -strictportbind -ip ${ip} -port ${port} +tv_port ${sourcetvport} +clientport ${clientport} -maxplayers ${maxplayers}"
 
 #### Advanced Variables ####
 


### PR DESCRIPTION
During installation of game server files, you ask for rcon password but don't enable it by default in the params. Is this intended? I spent a good couple hours troubleshooting why i couldn't connect to my rcon port and found out the default params doesn't enable rcon.
