### PR TITLE
Left4Dead2 script made safer for dirnames/filenames with spaces, and some other stuff

### DIFF
--- a/Left4Dead2/l4d2server
+++ b/Left4Dead2/l4d2server
@@ -3,7 +3,7 @@
 # Server Management Script
 # Author: Daniel Gibbs
 # Website: http://danielgibbs.co.uk
-# Version: 251213
+# Version: 251214
 
 #### Variables ####
 
@@ -40,8 +40,8 @@ servercfg="${filesdir}/left4dead2/cfg/${servicename}.cfg"
 backupdir="backups"
 
 # Server Details
-servername=$(grep -s hostname ${servercfg} | sed 's/hostname //g'|sed 's/"//g')
-rcon=$(grep -s rcon_password ${servercfg} | sed 's/rcon_password //g'|sed 's/"//g')
+servername=$(grep -s hostname "${servercfg}" | sed 's/hostname //g'|sed 's/"//g')
+rcon=$(grep -s rcon_password "${servercfg}" | sed 's/rcon_password //g'|sed 's/"//g')
 
 # Logging
 logdays="7"
@@ -61,6 +61,10 @@ consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%d-%m-%Y-%H-%M-
 # unless you know
 # what you are doing
 
+fn_scriptlog(){
+	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: '$1'" >> ${scriptlog}
+}
+
 fn_rootcheck(){
 if [ `whoami` = "root" ]; then
 	echo -e "\r\033[K[\e[0;31m FAIL \e[0;39m] Script will not run as root!"
@@ -69,7 +73,7 @@ fi
 }
 
 fn_syscheck(){
-if [ ! -e ${filesdir} ]; then
+if [ ! -e "${filesdir}" ]; then
 	echo -e "\r\033[K[\e[0;31m FAIL \e[0;39m] Cannot access ${filesdir}: No such directory"
 	exit
 fi
@@ -82,38 +86,38 @@ getip=$(/sbin/ifconfig | grep "inet addr" | awk -F: '{print $2}' | awk '{print $
 getipwc=$(/sbin/ifconfig | grep "inet addr" | awk -F: '{print $2}' | awk '{print $1}'|grep -v 127.0.0.1|wc -l)
 if [ "${ip}" == "0.0.0.0" ]||[ "${ip}" == "" ]; then
 	if [ "${getipwc}" -ge "2" ]; then
-		echo -en "[\e[1;33m WARN \e[0;39m] Multiple active interfaces.\n\n" 
+		echo -en "[\e[1;33m WARN \e[0;39m] Multiple active interfaces.\n\n"
 		echo -en "Manually specify the IP in ${selfname}\n"
 		echo -en "Set ip=\"0.0.0.0\" to one of the following:\n"
 		echo -en "${getip}\n"
 		exit
-	else 
+	else
 		ip=${getip}
 	fi
 fi
 }
 
 fn_logmanager(){
-if [ ! -e ${consolelog} ]; then
-	touch ${consolelog}
+if [ ! -e "${consolelog}" ]; then
+	touch "${consolelog}"
 fi
 # log manager will active if finds logs older than ${logdays}
-if [ `find ${scriptlogdir}/* -mtime +${logdays} |wc -l` -ne "0" ]; then
+if [ `find "${scriptlogdir}"/* -mtime +${logdays} |wc -l` -ne "0" ]; then
 	echo -e "\r\033[K[\e[0;32m  OK  \e[0;39m] Starting log cleaner"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Starting log cleaner" >> ${scriptlog}
+	fn_scriptlog "Starting log cleaner"
 	sleep 1
 	echo -e "[\e[0;36m INFO \e[0;39m] Removing logs older than ${logdays} days"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Removing logs older than ${logdays} days" >> ${scriptlog}
+	fn_scriptlog "Removing logs older than ${logdays} days"
 	sleep 1
-	find ${scriptlogdir}/* -mtime +${logdays} |tee >> ${scriptlog}
-	find ${consolelogdir}/* -mtime +${logdays} |tee >> ${scriptlog}
-	scriptcount=$(find ${scriptlogdir}/* -mtime +${logdays}|wc -l)
-	consolecount=$(find ${consolelogdir}/* -mtime +${logdays}|wc -l)
+	find "${scriptlogdir}"/* -mtime +${logdays} |tee >> "${scriptlog}"
+	find "${consolelogdir}"/* -mtime +${logdays} |tee >> "${scriptlog}"
+	scriptcount=$(find "${scriptlogdir}/*" -mtime +${logdays}|wc -l)
+	consolecount=$(find "${consolelogdir}/*" -mtime +${logdays}|wc -l)
 	count=$((${scriptcount} + ${consolecount}))
-	find ${scriptlogdir}/* -mtime +${logdays} -exec rm {} \;
-	find ${consolelogdir}/* -mtime +${logdays} -exec rm {} \;
+	find "${scriptlogdir}"/* -mtime +${logdays} -exec rm {} \;
+	find "${consolelogdir}"/* -mtime +${logdays} -exec rm {} \;
 	echo -e "[\e[0;36m INFO \e[0;39m] Log cleaner removed ${count} log files"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Log cleaner removed ${count} log files" >> ${scriptlog}
+	fn_scriptlog "Log cleaner removed ${count} log files"
 fi
 }
 
@@ -141,11 +145,11 @@ fn_stopserver
 echo -en "\r\033[K[ .... ] Starting debug mode ${servicename}: ${servername}"
 sleep 0.5
 echo -en "\r\033[K[\e[0;32m  OK  \e[0;39m] Starting debug mode ${servicename}: ${servername}"
-echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Started debug mode ${servername} " >> ${scriptlog}
+fn_scriptlog "Started debug mode ${servername} "
 sleep 0.5
 echo -en "\n"
-cd ${filesdir}
-./srcds_run ${parms} -debug
+cd "${filesdir}"
+./srcds_run "${parms}" -debug
 }
 
 fn_console(){
@@ -171,7 +175,7 @@ sleep 0.5
 tmuxwc=$(tmux list-sessions 2>&1|awk '{print $1}'|grep -v failed|grep -E "^${servicename}:"|wc -l)
 if [ ${tmuxwc} -eq 1 ]; then
 	echo -e "\r\033[K[\e[0;32m  OK  \e[0;39m] Starting ${servicename} console"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Console accessed" >> ${scriptlog}
+	fn_scriptlog "Console accessed"
 	sleep 1
 	tmux attach-session -t ${servicename}
 else
@@ -223,14 +227,14 @@ fi
 echo -en "\r\033[K[ .... ] Starting backup ${servicename}: ${servername}"
 sleep 1
 echo -en "\r\033[K[\e[0;32m  OK  \e[0;39m] Starting backup ${servicename}: ${servername}"
-echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Backup started" >> ${scriptlog}
+fn_scriptlog "Backup started"
 sleep 1
 echo -en "\n"
-cd ${rootdir}
-mkdir ${backupdir} > /dev/null 2>&1
-tar -cvzf ${backupdir}/${backupname}.tar.gz --exclude ${backupdir} *
+cd "${rootdir}"
+mkdir -p "${backupdir}" > /dev/null 2>&1
+tar -cvzf "${backupdir}/${backupname}.tar.gz" --exclude "${backupdir}" *
 echo -en "\r\033[K${servicename} Backup complete"
-echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Backup complete" >> ${scriptlog}
+fn_scriptlog "Backup complete"
 }
 
 fn_distro(){
@@ -280,19 +284,19 @@ fn_load
 	echo -e "Avg Load${load}\n"
 	echo -e "========================================\nLogs\n========================================\n"
 	echo -e "Script log\n===================\n"
-}|tee ${scriptlogdir}/${servicename}-email.log > /dev/null 2>&1
-tail -25 ${scriptlog} >> ${emaillog}
-if [ ! -z ${consolelog} ]; then
-	echo -e "\n\nConsole log\n====================\n" >> ${emaillog}
-	tail -25 ${consolelog} >> ${emaillog}
+}|tee "${scriptlogdir}/${servicename}-email.log" > /dev/null 2>&1
+tail -25 "${scriptlog}" >> "${emaillog}"
+if [ ! -z "${consolelog}" ]; then
+	echo -e "\n\nConsole log\n====================\n" >> "${emaillog}"
+	tail -25 "${consolelog}" >> "${emaillog}"
 fi
-if [ ! -z ${gamelogdir} ]; then
-	echo -e "\n\nServer log\n====================\n" >> ${emaillog}
-	tail ${gamelogdir}/*|grep -v "==>"|sed '/^$/d'|tail -25 >> ${emaillog}
+if [ ! -z "${gamelogdir}" ]; then
+	echo -e "\n\nServer log\n====================\n" >> "${emaillog}"
+	tail "${gamelogdir}"/* | grep -v "==>"|sed '/^$/d'|tail -25 >> "${emaillog}"
 fi
-mail -s "${subject}" ${email} < ${emaillog}
+mail -s "${subject}" ${email} < "${emaillog}"
 echo -en "[\e[0;36m INFO \e[0;39m] Sent email notification to ${email}"
-echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Sent email notification to ${email}" >> ${scriptlog}
+fn_scriptlog "Sent email notification to ${email}"
 sleep 1
 echo -en "\n"
 }
@@ -300,7 +304,7 @@ echo -en "\n"
 fn_emailtest(){
 fn_rootcheck
 fn_syscheck
-echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Emailing test notification" >> ${scriptlog}
+fn_scriptlog "Emailing test notification"
 if [ "${emailnotification}" = "on" ]; then
 	subject="${servicename} Email Test Notification - Testing ${servername}"
 	failurereason="Testing ${servicename} email notification"
@@ -308,7 +312,7 @@ if [ "${emailnotification}" = "on" ]; then
 	fn_emailnotification
 else
 	echo -e "\r\033[K[\e[0;31m FAIL \e[0;39m] Email notification not enabled"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Email notification not enabled" >> ${scriptlog}
+	fn_scriptlog "Email notification not enabled"
 fi
 sleep 0.5
 echo -en "\n"
@@ -325,16 +329,16 @@ if [ -f gsquery.py ]; then
 		port=$((${port} + 1))
 	fi
 	echo -en "\r\033[K[\e[0;36m INFO \e[0;39m] Monitoring ${servicename}: Detected gsquery.py"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Detected gsquery.py " >> ${scriptlog}
+	fn_scriptlog "Detected gsquery.py "
 	sleep 1
 	echo -en "\r\033[K[ .... ] Monitoring ${servicename}: Querying port: ${ip}:${port}: QUERYING"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Querying port: ${ip}:${port}: QUERYING" >> ${scriptlog}
+	fn_scriptlog "Querying port: ${ip}:${port}: QUERYING"
 	serverquery=$(./gsquery.py -a ${ip} -p ${port} -e ${engine} 2>&1)
 	exitcode=$?
-	sleep 1	
+	sleep 1 
 	if [ "${exitcode}" == "1" ]||[ "${exitcode}" == "2" ]||[ "${exitcode}" == "3" ]||[ "${exitcode}" == "4" ]; then
 		echo -en "\r\033[K[\e[0;31m FAIL \e[0;39m] Monitoring ${servicename}: Querying port: ${ip}:${port}: ${serverquery}"
-		echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Querying port: ${ip}:${port}: ${serverquery}" >> ${scriptlog}
+		fn_scriptlog "Querying port: ${ip}:${port}: ${serverquery}"
 		sleep 1
 		echo -en "\n"
 		if [ "${emailnotification}" = "on" ]; then
@@ -347,13 +351,13 @@ if [ -f gsquery.py ]; then
 		exit
 	elif [ "${exitcode}" == "0" ]; then
 		echo -en "\r\033[K[\e[0;32m  OK  \e[0;39m] Monitoring ${servicename}: Querying port: ${ip}:${port}: OK"
-		echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Querying port: ${ip}:${port}: OK" >> ${scriptlog}		
+		fn_scriptlog "Querying port: ${ip}:${port}: OK"
 		sleep 1
 		echo -en "\n"
 		exit
 	elif [ "${exitcode}" == "126" ]; then
 		echo -en "\r\033[K[\e[0;31m FAIL \e[0;39m] Monitoring ${servicename}: Querying port: ${ip}:${port}: ERROR: ./gsquery.py: Permission denied"
-		echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Querying port: ${ip}:${port}: ./gsquery.py: Permission denied" >> ${scriptlog}		
+		fn_scriptlog "Querying port: ${ip}:${port}: ./gsquery.py: Permission denied"
 		sleep 1
 		echo -en "\n"
 		echo "Attempting to resolve automatically"
@@ -371,7 +375,7 @@ if [ -f gsquery.py ]; then
 		fi
 	else
 		echo -en "\r\033[K[\e[0;31m FAIL \e[0;39m] Monitoring ${servicename}: Querying port: ${ip}:${port}: UNKNOWN ERROR"
-		echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Querying port: ${ip}:${port}: UNKNOWN ERROR" >> ${scriptlog}		
+		fn_scriptlog "Querying port: ${ip}:${port}: UNKNOWN ERROR"
 		sleep 1
 		echo -en "\n"
 		./gsquery.py -a ${ip} -p ${port} -e ${engine}
@@ -385,41 +389,41 @@ fn_rootcheck
 fn_syscheck
 fn_autoip
 echo -en "\r\033[K[ .... ] Monitoring ${servicename}: ${servername}"
-echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Monitoring ${servername}" >> ${scriptlog}
+fn_scriptlog "Monitoring ${servername}"
 sleep 1
 updatecheck=$(ps -ef|grep "${selfname} update"|grep -v grep|wc -l)
 if [ "${updatecheck}" = "0" ]; then
 	echo -en "\r\033[K[ .... ] Monitoring ${servicename}: Checking session: CHECKING"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Checking session: CHECKING" >> ${scriptlog}
+	fn_scriptlog "Checking session: CHECKING"
 	sleep 1
 	tmuxwc=$(tmux list-sessions 2>&1|awk '{print $1}'|grep -v failed|grep -E "^${servicename}:"|wc -l)
 	if [ ${tmuxwc} -eq 1 ]; then
 		echo -en "\r\033[K[\e[0;32m  OK  \e[0;39m] Monitoring ${servicename}: Checking session: OK"
-		echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Checking session: OK" >> ${scriptlog}
+		fn_scriptlog "Checking session: OK"
 		sleep 1
 		echo -en "\n"
 		fn_serverquery
 		exit
 	else
 		echo -en "\r\033[K[\e[0;31m FAIL \e[0;39m] Monitoring ${servicename}: Checking session: FAIL"
-		echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Checking session: FAIL" >> ${scriptlog}
+		fn_scriptlog "Checking session: FAIL"
 		sleep 1
-		echo -en "\n"		
+		echo -en "\n"	   
 		if [ "${emailnotification}" = "on" ]; then
 			subject="${servicename} Monitor - Starting ${servername}"
 			failurereason="${servicename} process not running"
 			actiontaken="${servicename} has been restarted"
 			fn_emailnotification
 		fi
-		echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Monitor is starting ${servername}" >> ${scriptlog}
-		fn_startserver	
+		fn_scriptlog "Monitor is starting ${servername}"
+		fn_startserver  
 	fi
 else
 	echo -e "[\e[0;36m INFO \e[0;39m] Monitoring ${servicename}: Detected SteamCMD is checking for updates"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Detected SteamCMD is checking for updates" >> ${scriptlog}
+	fn_scriptlog "Detected SteamCMD is checking for updates"
 	sleep 1
 	echo -e "[\e[0;36m INFO \e[0;39m] Monitoring ${servicename}: When updates complete ${servicename} will start"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: When updates complete ${servicename} will start" >> ${scriptlog}
+	fn_scriptlog "When updates complete ${servicename} will start"
 fi
 }
 
@@ -429,14 +433,14 @@ fn_syscheck
 echo -en "\r\033[K[ .... ] Updating ${servicename}: ${servername}"
 sleep 0.5
 echo -en "\r\033[K[\e[0;32m  OK  \e[0;39m] Updating ${servicename}: ${servername}"
-echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Updating ${servername}" >> ${scriptlog}
-cd ${rootdir}
+fn_scriptlog "Updating ${servername}"
+cd "${rootdir}"
 cd steamcmd
-./steamcmd.sh +login anonymous +force_install_dir ${filesdir} +app_update ${appid} validate +quit |tee -a ${scriptlog}
+./steamcmd.sh +login anonymous +force_install_dir "${filesdir}" +app_update ${appid} validate +quit |tee -a "${scriptlog}"
 }
 
 fn_restartserver(){
-echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Restarting ${servername}" >> ${scriptlog}
+fn_scriptlog "Restarting ${servername}"
 fn_stopserver
 fn_startserver
 }
@@ -446,15 +450,15 @@ fn_rootcheck
 fn_syscheck
 pid=$(tmux list-sessions 2>&1|awk '{print $1}'|grep -E "^${servicename}:"|wc -l)
 echo -en "\r\033[K[ .... ] Stopping ${servicename}: ${servername}"
-echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Stopping ${servername}" >> ${scriptlog}
+fn_scriptlog "Stopping ${servername}"
 sleep 0.5
 if [ "${pid}" == "0" ]; then
 	echo -en "\r\033[K[\e[0;31m FAIL \e[0;39m] Stopping ${servicename}: ${servername} is already stopped"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: ${servername} is already stopped" >> ${scriptlog}
+	fn_scriptlog "${servername} is already stopped"
 else
 	tmux kill-session -t ${servicename}
 	echo -en "\r\033[K[\e[0;32m  OK  \e[0;39m] Stopping ${servicename}: ${servername}"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Stopped ${servername}" >> ${scriptlog}
+	fn_scriptlog "Stopped ${servername}"
 fi
 sleep 0.5
 echo -en "\n"
@@ -467,29 +471,29 @@ fn_autoip
 fn_logmanager
 tmuxwc=$(tmux list-sessions 2>&1|awk '{print $1}'|grep -v failed|grep -E "^${servicename}:"|wc -l)
 if [ ${tmuxwc} -eq 0 ]; then
-	mv ${scriptlog} ${scriptlogdate}
-	mv ${consolelog} ${consolelogdate}
+	mv "${scriptlog}" "${scriptlogdate}"
+	mv "${consolelog}" "${consolelogdate}"
 fi
 echo -en "\r\033[K[ .... ] Starting ${servicename}: ${servername}"
-echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Starting ${servername}" >> ${scriptlog}
+fn_scriptlog "Starting ${servername}"
 sleep 0.5
 if [ ${tmuxwc} -eq 1 ]; then
 	echo -en "\r\033[K[\e[0;36m INFO \e[0;39m] Starting ${servicename}: ${servername} is already running"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: ${servername} is already running" >> ${scriptlog}
+	fn_scriptlog "${servername} is already running"
 	sleep 0.5
 	echo -en "\n"
 	exit
 fi
-cd ${filesdir}
-tmux new-session -d -s ${servicename} "./srcds_run ${parms} |tee -a ${consolelog}"
+cd "${filesdir}"
+tmux new-session -d -s ${servicename} "./srcds_run ${parms} |tee -a '${consolelog}'"
 sleep 1
 tmuxwc=$(tmux list-sessions 2>&1|awk '{print $1}'|grep -E "^${servicename}:"|wc -l)
 if [ ${tmuxwc} -eq 0 ]; then
 	echo -en "\r\033[K[\e[0;31m FAIL \e[0;39m] Starting ${servicename}: Failed to start ${servername}"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: failed to start ${servername}" >> ${scriptlog}
+	fn_scriptlog "failed to start ${servername}"
 else
 	echo -en "\r\033[K[\e[0;32m  OK  \e[0;39m] Starting ${servicename}: ${servername}"
-	echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: Started ${servername}" >> ${scriptlog}
+	fn_scriptlog "Started ${servername}"
 fi
 sleep 0.5
 echo -en "\n"
@@ -502,8 +506,8 @@ echo "============================"
 echo ""
 echo "${servername} Ports"
 echo "======================="
-servername=$(grep -s hostname ${servercfg} | sed 's/hostname //g'|sed 's/"//g')
-rcon=$(grep -s rcon_password ${servercfg} | sed 's/rcon_password //g'|sed 's/"//g')
+servername=$(grep -s hostname "${servercfg}" | sed 's/hostname //g'|sed 's/"//g')
+rcon=$(grep -s rcon_password "${servercfg}" | sed 's/rcon_password //g'|sed 's/"//g')
 echo "Ports the server is currently using"
 echo ""
 echo "DIRECTION	DESCRIPTION		PORT"
@@ -544,8 +548,8 @@ echo ""
 fn_steamdl(){
 echo "Installing Steam"
 echo "================================="
-cd ${rootdir}
-mkdir steamcmd
+cd "${rootdir}"
+mkdir -p steamcmd
 cd steamcmd
 if [ ! -f steamcmd.sh ]; then
 	wget http://media.steampowered.com/client/steamcmd_linux.tar.gz
@@ -571,7 +575,7 @@ done
 fn_install(){
 fn_rootcheck
 fn_header
-if [ -d ${filesdir} ]; then
+if [ -d "${filesdir}" ]; then
 	echo "${gamename} Server is already installed here:"
 	pwd
 	echo ""
@@ -601,16 +605,19 @@ fn_steamdl
 echo ""
 echo "Installing ${gamename} Server"
 echo "================================="
-	cd ${rootdir}/steamcmd
-	mkdir -v ${filesdir}
-	touch install.txt
-	chmod 0600 install.txt
-	echo "login anonymous" > install.txt
-	echo "force_install_dir ${filesdir}" >> install.txt
-	echo "app_update ${appid} validate" >> install.txt
-	echo "quit" >> install.txt
-	STEAMEXE=steamcmd ./steamcmd.sh +runscript install.txt
-	rm install.txt
+	cd "${rootdir}/steamcmd"
+	mkdir -pv "${filesdir}"
+	# Steam's installscript does not support quotes!!
+	# That is why the block below is commented out
+	# touch install.txt
+	# chmod 0600 install.txt  
+	# echo "login anonymous" > install.txt
+	# echo "force_install_dir '${filesdir}'" >> install.txt
+	# echo "app_update ${appid} validate" >> install.txt
+	# echo "quit" >> install.txt
+	#STEAMEXE=steamcmd ./steamcmd.sh +runscript install.txt
+	#rm install.txt
+	STEAMEXE=steamcmd ./steamcmd.sh +login anonymous +force_install_dir "${filesdir}" +app_update "${appid}" validate +quit
 	echo ""
 	echo "================================="
 	while true; do
@@ -629,13 +636,13 @@ echo "================================="
 	sleep 1
 	echo ""
 	echo "Creating server.cfg"
-	touch ${filesdir}/left4dead2/cfg/server.cfg
-	echo "exec ${servicename}.cfg" > ${filesdir}/left4dead2/cfg/server.cfg
+	touch "${filesdir}/left4dead2/cfg/server.cfg"
+	echo "exec ${servicename}.cfg" > "${filesdir}/left4dead2/cfg/server.cfg"
 	sleep 1
 	echo "Creating default config file:"
 	sleep 0.5
 	echo "${servercfg}"
-	touch ${servercfg}
+	touch "${servercfg}"
 	{
 		echo -e "// server name"
 		echo -e "hostname \"${servername}\""
@@ -652,25 +659,25 @@ echo "================================="
 		echo -e "sv_logecho 1"
 		echo -e "sv_logfile 1"
 		echo -e "sv_log_onefile 0"
-	}|tee ${servercfg} > /dev/null 2>&1
+	}|tee "${servercfg}" > /dev/null 2>&1
 	sleep 1
 	echo ""
 	echo "Creating log directorys"
-	mkdir -v ${rootdir}/log
-	mkdir -v ${scriptlogdir}
-	mkdir -v ${consolelogdir}
-	touch ${consolelog}
+	mkdir -pv "${rootdir}/log"
+	mkdir -pv "${scriptlogdir}"
+	mkdir -pv "${consolelogdir}"
+	touch "${consolelog}"
 	if [ ! -h ${rootdir}/log/server ]; then
-		ln -sv ${gamelogdir} ${rootdir}/log/server
+		ln -sv "${gamelogdir}" "${rootdir}/log/server"
 	else
 		echo "Symbolic link ${gamelogdir} => ${rootdir}/log/server already exists!"
 	fi
 	sleep 1
 	echo ""
 	echo "Applying steamclient.so fix"
-	mkdir -v ${HOME}/.steam
-	mkdir -v ${HOME}/.steam/sdk32
-	cp -v ${filesdir}/bin/steamclient.so ${HOME}/.steam/sdk32/steamclient.so
+	mkdir -pv ${HOME}/.steam
+	mkdir -pv ${HOME}/.steam/sdk32
+	cp -v "${filesdir}/bin/steamclient.so" "${HOME}/.steam/sdk32/steamclient.so"
 	sleep 1
 	fn_header
 	fn_details


### PR DESCRIPTION
- Made the script safer with destinations with spaces in them by
  double quoting some of the variables that pertain to dirnames
- Cleaned up a couple of lines with trailing spaces
- Added a function for scriplogging, and replaced the lines where it
  uses them. This has been tested, it works just like it used to
- Had to replace install.txt steam script with a commandline (like for
  update), because steam install script treats quotes as literals:
  http://forums.steampowered.com/forums/showthread.php?t=2896163
  The "fix" in this forum post is not using spaces :)
- Replaced some "mkdir -v" commands with "mkdir -pv" so as to avoid
  getting errors if the directory already exists

Tested on a completely fresh homedir:
- install
- start
- stop
- restart
- update
- monitor
- email-test
- details
- backup
- console
- debug

All test completed successfully!
