### PR TITLE
Few small fixes

### DIFF
--- a/CounterStrikeGlobalOffensive/csgoserver
+++ b/CounterStrikeGlobalOffensive/csgoserver
@@ -669,7 +669,7 @@ echo "Installing ${gamename} Server"
 echo "================================="
 sleep 1
 mkdir -pv "${filesdir}"
-echo -n "730" >> ${rootdir}/serverfiles/steamappid.txt
+echo -n "730" >> ${filesdir}/steam_appid.txt
 cd "${rootdir}/steamcmd"
 STEAMEXE=steamcmd ./steamcmd.sh +login ${steamuser} ${steampass} +force_install_dir "${filesdir}" +app_update ${appid} validate +quit
 echo ""


### PR DESCRIPTION
-Seperated startup parameters  on to individual lines for readability and easier editing
-Added print functions to declutter messages while running the script
-Added tickrate server startup parameter, defaults to 64 as usual
-Added output of steam_appid.txt file, without it the server might continually restart, it is 730 for CSGO, as opposed to the 740 used for installing the CSGO server

No functionality is really changed, other than the output of the steam_appid.txt file, mostly these changes  are to help people who need to edit the script.
