### PR TITLE
remove tickrate command for servers which do not support it

### DIFF
--- a/CounterStrikeSource/cssserver
+++ b/CounterStrikeSource/cssserver
@@ -19,7 +19,6 @@ steampass=""
 # Start Variables
 defaultmap="de_dust2"
 maxplayers="16"
-tickrate="64"
 port="27015"
 sourcetvport="27020"
 clientport="27005"
@@ -27,7 +26,7 @@ ip="0.0.0.0"
 
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
 fn_parms(){
-parms="-game cstrike -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} -tickrate ${tickrate} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
+parms="-game cstrike -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
 }
 
 #### Advanced Variables ####

--- a/DayOfDefeatSource/dodsserver
+++ b/DayOfDefeatSource/dodsserver
@@ -19,7 +19,6 @@ steampass=""
 # Start Variables
 defaultmap="dod_Anzio"
 maxplayers="16"
-tickrate="64"
 port="27015"
 sourcetvport="27020"
 clientport="27005"
@@ -27,7 +26,7 @@ ip="0.0.0.0"
 
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
 fn_parms(){
-parms="-game dod -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} -tickrate ${tickrate} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
+parms="-game dod -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
 }
 
 #### Advanced Variables ####

--- a/Left4Dead2/l4d2server
+++ b/Left4Dead2/l4d2server
@@ -19,7 +19,6 @@ steampass=""
 # Start Variables
 defaultmap="c5m1_waterfront"
 maxplayers="8"
-tickrate="64"
 port="27015"
 sourcetvport="27020"
 clientport="27005"
@@ -27,7 +26,7 @@ ip="0.0.0.0"
 
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
 fn_parms(){
-parms="-game left4dead2 -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} -tickrate ${tickrate} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
+parms="-game left4dead2 -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
 }
 
 #### Advanced Variables ####

--- a/TeamFortress2/tf2server
+++ b/TeamFortress2/tf2server
@@ -19,7 +19,6 @@ steampass=""
 # Start Variables
 defaultmap="de_dust2"
 maxplayers="16"
-tickrate="64"
 port="27015"
 sourcetvport="27020"
 clientport="27005"
@@ -27,7 +26,7 @@ ip="0.0.0.0"
 
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
 fn_parms(){
-parms="-game tf -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} -tickrate ${tickrate} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
+parms="-game tf -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
 }
 
 #### Advanced Variables ####


### PR DESCRIPTION
as per https://developer.valvesoftware.com/wiki/Source_Multiplayer_Networking it is not possible to change the tickrate for these games since June 2010
