### PR TITLE
Minor improvements, more options

### DIFF
--- a/NaturalSelection2/ns2server
+++ b/NaturalSelection2/ns2server
@@ -359,7 +359,7 @@ if [ ! -z "${gamelogdir}" ]; then
 	echo -e "\n\nServer log\n====================\n" >> "${emaillog}"
 	tail "${gamelogdir}"/*|grep -v "==>"|sed '/^$/d'|tail -25 >> "${emaillog}"
 fi
-mail -s "${subject}" ${email} < "${emaillog}"
+cat -v "${emaillog}" | mail -s "${subject}" ${email}
 fn_printinfo "Sent email notification to ${email}"
 sleep 1
 echo -en "\n"


### PR DESCRIPTION
Moved rootdir variable so that it's easier to define paths in fn_parms()
Fixed password parameter by adding double quotes - Error: Invalid command line (Expected value for option 'password')
Added double quotes to text type parameters - don't put quotes in the password variables or it'll break!
Added configpath variable to define where configs are loaded from (used to load from ~/.config/_, but now will load from ~/server1/_)
Added mods parameter; add mod ids delimited by space e.g. to use NS2+ and Shine: "812f004 706d242"
Added modstorage parameter; define a directory to store mods downloaded from Steam Workshop (used to load from ~/.config/Workshop/_, but now will load from ~/server1/Workshop/_)
