### PR TITLE
Add native workshop support

### DIFF
--- a/GarrysMod/gmodserver
+++ b/GarrysMod/gmodserver
@@ -17,6 +17,7 @@ steamuser="anonymous"
 steampass=""
 
 # Workshop Variables
+# http://wiki.garrysmod.com/page/Workshop_for_Dedicated_Servers
 workshopauth=""
 workshopcollectionid=""
 


### PR DESCRIPTION
To add on the instruction page:
To get the workshop auth code, go to http://steamcommunity.com/dev/apikey and generate a code.
To get the workshop collection id, take the URL, for example http://steamcommunity.com/sharedfiles/filedetails/?id=123456789, and use the trailing numbers for the id value.
