### PR TITLE
fixed 'syntax error unexpected end of file'

### DIFF
--- a/Left4Dead/l4dserver
+++ b/Left4Dead/l4dserver
@@ -659,6 +659,7 @@ cd "${filesdir}"
 cp -v "${rootdir}/steamcmd/linux32/libstdc++.so.6" "${filesdir}"
 sleep 1
 echo ""
+}
 
 fn_header(){
 clear


### PR DESCRIPTION
There was a syntax error (a missing '}'), which lead to an syntax error ("unexpected end of file")
