### PR TITLE
Remove old GLIBC fix, awkwardly does both

### DIFF
--- a/GarrysMod/gmodserver
+++ b/GarrysMod/gmodserver
@@ -736,23 +736,6 @@ sleep 1
 echo ""
 }
 
-fn_glibcfix(){
-echo "Applying GLIBC_2.15 fix"
-echo "================================="
-sleep 1
-mkdir -pv "${rootdir}/tmp"
-echo "Downloading GLIBC_2.15"
-wget -q http://security.ubuntu.com/ubuntu/pool/main/e/eglibc/libc6_2.15-0ubuntu10.6_i386.deb -O ${rootdir}/tmp/libc6_2.15-0ubuntu10.6_i386.deb
-echo "Extracting files"
-dpkg -x ${rootdir}/tmp/libc6_2.15-0ubuntu10.6_i386.deb ${rootdir}/tmp/
-echo "Copying GLIBC_2.15 files into bin"
-cp ${rootdir}/tmp/lib/i386-linux-gnu/* ${rootdir}/serverfiles/bin/
-echo "Removing temporary folder"
-rm -fr ${rootdir}/tmp/
-sleep 1
-echo ""
-}
-
 fn_loginstall(){
 echo "Creating log directorys"
 echo "================================="
@@ -813,7 +796,6 @@ fn_header
 fn_steamdl
 fn_steaminstall
 fn_steamfix
-fn_glibcfix
 fn_loginstall
 fn_gmoddeps
 echo "Configuring ${gamename} Server"


### PR DESCRIPTION
```
=================================
Was the install successful? [y/N]y

Applying steamclient.so fix
=================================
‘/home/dg/gmod/steamcmd/linux32/steamclient.so’ -> ‘/root/.steam/sdk32/steamclient.so’

Applying GLIBC_2.15 fix
=================================
mkdir: created directory ‘/home/dg/gmod/tmp’
Downloading GLIBC_2.15
Extracting files
dpkg-deb: error: `/home/dg/gmod/tmp/libc6_2.15-0ubuntu10.6_i386.deb' is not a debian format archive
Copying GLIBC_2.15 files into bin
cp: cannot stat ‘/home/dg/gmod/tmp/lib/i386-linux-gnu/*’: No such file or directory
Removing temporary folder

Creating log directorys
=================================
mkdir: created directory ‘/home/dg/gmod/log’
mkdir: created directory ‘/home/dg/gmod/log/script’
mkdir: created directory ‘/home/dg/gmod/log/console’
‘/home/dg/gmod/log/server’ -> ‘/home/dg/gmod/serverfiles/garrysmod/logs’

Copying libstdc++.so.6
=================================
‘/home/dg/gmod/steamcmd/linux32/libstdc++.so.6’ -> ‘/home/dg/gmod/serverfiles/libstdc++.so.6’

Applying GLIBC_2.15 fix
=================================
2014-09-01 02:31:07 URL:https://raw.githubusercontent.com/dgibbs64/linuxgameservers/master/GarrysMod/dependencies/libc.so.6 [1734120/1734120] -> "libc.so.6" [1]
2014-09-01 02:31:07 URL:https://raw.githubusercontent.com/dgibbs64/linuxgameservers/master/GarrysMod/dependencies/libm.so.6 [173576/173576] -> "libm.so.6" [1]
2014-09-01 02:31:08 URL:https://raw.githubusercontent.com/dgibbs64/linuxgameservers/master/GarrysMod/dependencies/libpthread.so.0 [124663/124663] -> "libpthread.so.0" [1]

Configuring Garrys's Mod Server...
```
