### PR TITLE
gamemode before map

### DIFF
--- a/GarrysMod/gmodserver
+++ b/GarrysMod/gmodserver
@@ -32,7 +32,7 @@ ip="0.0.0.0"
 
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
 fn_parms(){
-parms="-game garrysmod -strictportbind -ip ${ip} -port ${port} +host_workshop_collection ${workshopcollectionid} -authkey ${workshopauth} +clientport ${clientport} +tv_port ${sourcetvport} +map ${defaultmap} +gamemode ${gamemode} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
+parms="-game garrysmod -strictportbind -ip ${ip} -port ${port} +host_workshop_collection ${workshopcollectionid} -authkey ${workshopauth} +clientport ${clientport} +tv_port ${sourcetvport} +gamemode ${gamemode} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
 }
 
 #### Advanced Variables ####


### PR DESCRIPTION
It is possible to have maps in the gamemodes folder in that case its a requirement for the game to know the gamemode is before it can change to a map.

If srcds can not find the map it will refuse to start.