### PR TITLE
fix: TS3 Version check

### DIFF
--- a/functions/fn_update_check
+++ b/functions/fn_update_check
@@ -200,7 +200,7 @@ currentbuild=$(cat $(find ./* -name 'ts3server*_0.log' 2> /dev/null | sort | egr
 ts3arch=$(ls $(find ${filesdir}/ -name 'ts3server_*_*' 2> /dev/null | grep -v 'ts3server_minimal_runscript.sh' | sort | tail -1) | egrep -o '(amd64|x86)' | tail -1)
 
 # Gets availablebuild info
-wget "http://dl.4players.de/ts/releases/?C=M;O=D" -q -O -| grep -i dir | egrep -o '<a href=\".*\/\">.*\/<\/a>' | egrep -o '[0-9\.?]+'|uniq > .ts3_version_numbers.tmp
+wget "http://dl.4players.de/ts/releases/?C=N;O=D" -q -O -| grep -i dir | egrep -o '<a href=\".*\/\">.*\/<\/a>' | egrep -o '[0-9\.?]+'|uniq > .ts3_version_numbers.tmp
 # Finds directory with most recent server version.
 while read ts3_version_number; do
 	wget --spider -q "http://dl.4players.de/ts/releases/${ts3_version_number}/teamspeak3-server_linux-${ts3arch}-${ts3_version_number}.tar.gz"


### PR DESCRIPTION
Now Versions are sorted against Name.

Bug: The update was installing v3.0.3 over my v3.0.11.2!
```
./ts3server update
[  OK  ] Update ts3-server: Checking for update: teamspeak.com

Update available:
        Current build: 3.0.11.2
        Available build: 3.0.3


Applying update...
[...]
```