### PR TITLE
fixed wrong else position

### DIFF
--- a/functions/fn_start
+++ b/functions/fn_start
@@ -166,10 +166,10 @@ if [ "${tmuxwc}" -eq 0 ]; then
 				fn_scriptlog "http://gameservermanagers.com/issues"
 			fi
 		fi
-	else
-		fn_printok "${servername}"
-		fn_scriptlog "Started ${servername}"
 	fi
+else
+	fn_printok "${servername}"
+	fn_scriptlog "Started ${servername}"	
 fi
 #rm "${scriptlogdir}/.${servicename}-tmux-error.tmp"
 echo -en "\n"


### PR DESCRIPTION
Fixed an 'else' that belonged to the wrong 'if block'. Introduced with 2799224afa8b75be71dde30e0a9d9e96c7e9fc51
When you start the server (when it was stopped) there won't be the OK message.

I think this 'else' shouldn't be there?
