### PR TITLE
Fixed parsing uptime when it has no decimal point

### DIFF
--- a/functions/fn_details_distro
+++ b/functions/fn_details_distro
@@ -57,7 +57,7 @@ swapfree=$(free ${option} | awk '/Swap:/ {print $4}')
 
 # Uptime
 uptime=$(</proc/uptime)
-uptime=${uptime%%.*}
+uptime=${uptime/[. ]*/}
 minutes=$(( uptime/60%60 ))
 hours=$(( uptime/60/60%24 ))
 days=$(( uptime/60/60/24 ))


### PR DESCRIPTION
Using lxc (Linux Containers) 1.0.3, with Ubuntu 14.04 x64 as host and guest.

In the host, /proc/uptime looks like "22821.86 178565.50". In the guest, "11752 0". This patch adds support for both.