### PR TITLE
Removed parameters from TeamSpeak 3

### DIFF
--- a/functions/fn_stop
+++ b/functions/fn_stop
@@ -40,7 +40,7 @@ if [ "${ts3status}" = "No server running (ts3server.pid is missing)" ];then
     fn_printfail "${servername} is already stopped"
     fn_scriptlog "${servername} is already stopped"
 else
-    ${filesdir}/ts3server_startscript.sh stop inifile=${ini} > /dev/null 2>&1
+    ${filesdir}/ts3server_startscript.sh stop > /dev/null 2>&1
     fn_printok "${servername}"
     fn_scriptlog "Stopped ${servername}"
 fi


### PR DESCRIPTION
Removed "inifile=${ini}" parameter from fn_stop_teamspeak3 since ts3server_startscript.sh stop doesn't handle parameters.