### PR TITLE
Fix fn_details_statusbottom in fn_details_source()

### DIFF
--- a/functions/fn_details
+++ b/functions/fn_details
@@ -372,6 +372,7 @@ fn_details_statusbottom
 }
 
 fn_details_source(){
+pid=$(tmux list-sessions 2>&1 | awk '{print $1}' | grep -Ec "^${servicename}:")
 fn_check_ip
 fn_parms
 fn_details_config


### PR DESCRIPTION
The function was not working properly since the pid variable is missing.
This solve the issue.