### PR TITLE
enhanced mod-support

### DIFF
--- a/Arma3/arma3server
+++ b/Arma3/arma3server
@@ -25,10 +25,11 @@ steampass="password"
 
 # Start Variables
 ip="0.0.0.0"
+srvport="2302"
 updateonstart="off"
 
 fn_parms(){
-parms="-netlog -ip=${ip} -cfg=${networkcfgfullpath} -config=${servercfgfullpath} -mod=${mods} -servermod=${servermods} -bepath=${bepath} -autoinit -loadmissiontomemory"
+parms="-netlog -ip=${ip} -port=${srvport} -cfg=${networkcfgfullpath} -config=${servercfgfullpath} -mod=${mods} -servermod=${servermods} -bepath=${bepath} -autoinit -loadmissiontomemory"
 }
 
 # ARMA 3 Modules
@@ -38,7 +39,12 @@ parms="-netlog -ip=${ip} -cfg=${networkcfgfullpath} -config=${servercfgfullpath}
 # mods/\@CBA_A3\;mods/\@task_force_radio
 # and chmod modules directories to 775
 mods=""
+
+# Server-side Mods
 servermods=""
+
+# Path to BattlEye
+# leave empty for default
 bepath=""
 
 #### Advanced Variables ####

--- a/Arma3/arma3server
+++ b/Arma3/arma3server
@@ -28,7 +28,7 @@ ip="0.0.0.0"
 updateonstart="off"
 
 fn_parms(){
-parms="-netlog -ip=${ip} -cfg=${networkcfgfullpath} -config=${servercfgfullpath} -mod=${mods}"
+parms="-netlog -ip=${ip} -cfg=${networkcfgfullpath} -config=${servercfgfullpath} -mod=${mods} -servermod=${servermods} -autoinit -loadmissiontomemory"
 }
 
 # ARMA 3 Modules
@@ -38,6 +38,7 @@ parms="-netlog -ip=${ip} -cfg=${networkcfgfullpath} -config=${servercfgfullpath}
 # mods/\@CBA_A3\;mods/\@task_force_radio
 # and chmod modules directories to 775
 mods=""
+servermods=""
 
 #### Advanced Variables ####
 

--- a/Arma3/arma3server
+++ b/Arma3/arma3server
@@ -28,7 +28,7 @@ ip="0.0.0.0"
 updateonstart="off"
 
 fn_parms(){
-parms="-netlog -ip=${ip} -cfg=${networkcfgfullpath} -config=${servercfgfullpath} -mod=${mods} -servermod=${servermods} -autoinit -loadmissiontomemory"
+parms="-netlog -ip=${ip} -cfg=${networkcfgfullpath} -config=${servercfgfullpath} -mod=${mods} -servermod=${servermods} -bepath=${bepath} -autoinit -loadmissiontomemory"
 }
 
 # ARMA 3 Modules
@@ -39,6 +39,7 @@ parms="-netlog -ip=${ip} -cfg=${networkcfgfullpath} -config=${servercfgfullpath}
 # and chmod modules directories to 775
 mods=""
 servermods=""
+bepath=""
 
 #### Advanced Variables ####
 

--- a/Arma3/cfg/lgsm-default.server.cfg
+++ b/Arma3/cfg/lgsm-default.server.cfg
@@ -120,3 +120,12 @@ doubleIdDetected = "";					//
 onUnsignedData = "kick (_this select 0)";
 onHackedData = 	"kick (_this select 0)";
 onDifferentData = "";
+
+// HEADLESS CLIENT SUPPORT
+// specify ip-adresses of allowed headless clients
+// if more than one:
+// headlessClients[]={"127.0.0.1", "192.168.0.1"};
+// localClient[]={"127.0.0.1", "192.168.0.1"};
+headlessClients[]={"127.0.0.1"};
+localClient[]={"127.0.0.1"};
+battleyeLicense=1;

--- a/Arma3/cfg/lgsm-default.server.cfg
+++ b/Arma3/cfg/lgsm-default.server.cfg
@@ -5,18 +5,20 @@
 
 
 // PORTS
-
+// please specify the serverport as a parameter in arma3server executable
+// it will automatically use the serverport including the next 3 for steam query & steam master.
+// the fourth port ist not documented in https://community.bistudio.com/wiki/Arma_3_Dedicated_Server#Port_Forwarding
 // Server Port
 //  default: 2302.
-serverport=2302;
+// serverport=2302;
 
 // Steam Master Port
 //  default: 2304.
-steamport=2304;
+// steamport=2304;
 
 // Steam Query Port
 //  default: 2303.
-steamqueryport=2303;
+//steamqueryport=2303;
 
 
 // GENERAL SETTINGS

--- a/functions/fn_details_config
+++ b/functions/fn_details_config
@@ -209,29 +209,29 @@ elif [ "${engine}" == "realvirtuality" ]; then
 		slots="\e[0;31mUNAVAILABLE\e[0m"
 	fi
 
-	# port
-	if [ -f "${servercfgfullpath}" ]; then
-		port=$(grep "serverport=" "${servercfgfullpath}" | grep -v // | tr -d '\r' | tr -cd '[:digit:]')
-	fi
-	if [ ! -n "${port}" ]; then
-		port="0"
-	fi
+        # port
+        if [ "${srvport}" != "" ]; then
+                        port=${srvport}
+        fi
+        if [ ! -n "${port}" ]; then
+                port="0"
+        fi
 
-	# query port
-	if [ -f "${servercfgfullpath}" ]; then
-		queryport=$(grep "steamqueryport=" "${servercfgfullpath}" | grep -v // | tr -d '\r' | tr -cd '[:digit:]')
-	fi
-	if [ ! -n "${queryport}" ]; then
-		queryport="0"
-	fi
+        # query port
+        if [ "${srvport}" != "" ]; then
+                queryport=$((srvport+1))
+        fi
+        if [ ! -n "${queryport}" ]; then
+                queryport="0"
+        fi
 
-	# master port
-	if [ -f "${servercfgfullpath}" ]; then
-		masterport=$(grep "steamport=" "${servercfgfullpath}" | grep -v // | tr -d '\r' | tr -cd '[:digit:]')
-	fi
-	if [ ! -n "${masterport}" ]; then
-		masterport="0"
-	fi
+        # master port
+        if [ "${srvport}" != "" ]; then
+                masterport=$((srvport+2))
+        fi
+        if [ ! -n "${masterport}" ]; then
+                masterport="0"
+        fi
 
 	fn_servercfgfullpath
 


### PR DESCRIPTION
added parameters. descriptions taken from: https://community.bistudio.com/wiki/Arma_3_Startup_Parameters

-servermod
Loads the specified sub-folders for different server-side (not broadcasted to clients) mods. Separated by semi-colons. Absolute path and multiple stacked folders are possible. 

-autoinit:
Automatically initialize mission just like first client does. Note: Server config file (server.cfg) must contain Persistent=1; , if it's 0 autoInit skips. 

-loadmissiontomemory: 
Server will load mission into memory on first client downloading it. Then it keeps it pre-processed pre-cached in memory for next clients, saving some server CPU cycles