### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/dgibbs64/linuxgsm.png?label=ready&title=Ready)](https://waffle.io/dgibbs64/linuxgsm)
 <h1>Linux Game Server Managers_</h1>
 <a href="http://gameservermanagers.com"><img src="https://github.com/dgibbs64/linuxgsm/blob/master/images/logo/lgsm-full-light.png" alt="linux Game Server Managers" width="600" /></a>
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/dgibbs64/linuxgsm

This was requested by a real person (user dgibbs64) on waffle.io, we're not trying to spam you.