### PR TITLE
Line break at end of IP warning

### DIFF
--- a/functions/check_ip.sh
+++ b/functions/check_ip.sh
@@ -25,7 +25,7 @@ else
 			echo -en "Set ip=\"0.0.0.0\" to one of the following:\n"
 			echo -en "${getip}\n"
 			echo -en ""
-			echo -en "http://gameservermanagers.com/network-interfaces"
+			echo -en "http://gameservermanagers.com/network-interfaces\n"
 			echo -en ""
 			exit 1
 		else


### PR DESCRIPTION
Not having the line break makes it a bit harder than just double-clicking to select the url and copy/paste it.