### PR TITLE
Replaced fix.sh with fix_csgo.sh

### DIFF
--- a/functions/update_dl.sh
+++ b/functions/update_dl.sh
@@ -24,7 +24,10 @@ else
 	${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" +quit|tee -a "${scriptlog}"
 fi
 
-fix.sh
+if [ "${gamename}" == "Counter Strike: Global Offensive" ]; then
+        echo -e '\n'
+        fix_csgo.sh
+fi
 }
 
 fn_teamspeak3_dl(){


### PR DESCRIPTION
fix.sh does not exist and causes an error while updating:

        [...]
        Success! App '740' already up to date.
        /home/csgoserver/functions/update_dl.sh: line 27: fix.sh: command not found
        [...]

Well... The workshopmapfix won't apply ever.

Instead of using _fix.sh_, the script will now use _fix_csgo.sh_, if the gamename is CS:GO (Counter Strike: Global Offensive).

        [...]
        Success! App '740' already up to date.
        
        
        workshopmapfix fixes the following error:
                http://forums.steampowered.com/forums/showthread.php?t=3170366
        
        Applying workshopmap fix.
        Complete! Applying workshopmap fix.
        [...]