### PR TITLE
Gmod tickrate and fix for many maps

### DIFF
--- a/GarrysMod/gmodserver
+++ b/GarrysMod/gmodserver
@@ -9,7 +9,7 @@ if [ -f ".dev-debug" ]; then
 	set -x
 fi
 
-version="190216"
+version="130316"
 
 #### Variables ####
 
@@ -35,7 +35,12 @@ port="27015"
 sourcetvport="27020"
 clientport="27005"
 ip="0.0.0.0"
+tickrate="66"
 updateonstart="off"
+
+# Custom Start Parameters
+# Default +r_hunkalloclightmaps 0, fixes a start issue on maps with many lights
+customparms="+r_hunkalloclightmaps 0"
 
 # Optional: Game Server Login Token
 # GSLT can be used for running a public server.
@@ -44,7 +49,7 @@ gslt=""
 
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
 fn_parms(){
-parms="-game garrysmod -strictportbind -ip ${ip} -port ${port} +host_workshop_collection ${workshopcollectionid} -authkey ${workshopauth} +clientport ${clientport} +tv_port ${sourcetvport} +gamemode ${gamemode} +map ${defaultmap} +sv_setsteamaccount ${gslt} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
+parms="-game garrysmod -strictportbind -ip ${ip} -port ${port} -tickrate {tickrate} +host_workshop_collection ${workshopcollectionid} -authkey ${workshopauth} +clientport ${clientport} +tv_port ${sourcetvport} +gamemode ${gamemode} +map ${defaultmap} +sv_setsteamaccount ${gslt} +servercfgfile ${servercfg} -maxplayers ${maxplayers} ${customparms}"
 }
 
 #### Advanced Variables ####


### PR DESCRIPTION
Fixes https://github.com/dgibbs64/linuxgsm/issues/685
Tickrate needs to be lowered in order to be able to handle a large amount of players.
Default tickrate is 66.66, but the -tickrate commnand will round numbers to the lower integer. So i'll default at 66 and not -the more accurate- 67 to not worry anyone with a "non standard" value.

For the +r_hunkalloclightmaps 0, it fixes the hunk overflow crash on server startup when using maps with too much lights (and there are a lot of them). It changes the way lights are stored in RAM, the 0 mode (default one a few years ago, and still default one on clients) can handle a way larger amount of lights, but a theoretically a bit slower way. I noticed no difference, so it's a good thing to fix it by default.