### PR TITLE
TS3 change password "No" answer is ignored

### DIFF
--- a/functions/command_ts3_server_pass.sh
+++ b/functions/command_ts3_server_pass.sh
@@ -24,7 +24,7 @@ while true; do
 	read -e -i "y" -p "Continue? [y/N]" yn
 	case $yn in
 	[Yy]* ) break;;
-	[Nn]* ) echo Exiting; return;;
+	[Nn]* ) echo Exiting; exit;;
 	* ) echo "Please answer yes or no.";;
 esac
 done


### PR DESCRIPTION
Even if we answer no to the "Continue?"-Question the script will stop and start the server.
It will only skip the enter new password part.

```
    fetching functions/command_ts3_server_pass.sh...OK

Teamspeak 3 ServerAdmin Password Change
============================

Press "CTRL+b d" to exit console.
Info! You are about to change the Teamspeak 3 ServerAdmin password.
Warning! Teamspeak 3 will restart during this process.

Continue? [y/N]n
Exiting
[ INFO ] Change password ts3-server: Applying new password
    fetching functions/command_stop.sh...OK
    fetching functions/check_deps.sh...OK
[  OK  ] Stopping ts3-server: Teamspeak 3 Server
[ INFO ] Change password ts3-server: Starting server with new password
    fetching functions/command_start.sh...OK
    fetching functions/check_tmux.sh...OK
    fetching functions/logs.sh...OK
[ .... ] Starting ts3-server: Teamspeak 3 ServerStarting the TeamSpeak 3 server
TeamSpeak 3 server started, for details please view the log file
[  OK  ] Starting ts3-server: Teamspeak 3 Server
[  OK  ] Stopping ts3-server: Teamspeak 3 Server
[  OK  ] Change password ts3-server: Password applied
[ .... ] Starting ts3-server: Teamspeak 3 ServerStarting the TeamSpeak 3 server
TeamSpeak 3 server started, for details please view the log file
[  OK  ] Starting ts3-server: Teamspeak 3 Server
```