### PR TITLE
Fix more TS3 change password related issues

### DIFF
--- a/functions/command_start.sh
+++ b/functions/command_start.sh
@@ -56,7 +56,7 @@ mv "${scriptlog}" "${scriptlogdate}"
 date > "${rootdir}/${lockselfname}"
 cd "${executabledir}"
 if [ "${ts3serverpass}" == "1" ];then
-	./ts3server_startscript.sh start serveradmin_password="${newpassword}" 
+	./ts3server_startscript.sh start serveradmin_password="${newpassword}" inifile="${servercfgfullpath}"
 else
 	./ts3server_startscript.sh start inifile="${servercfgfullpath}" > /dev/null 2>&1
 fi

--- a/functions/command_ts3_server_pass.sh
+++ b/functions/command_ts3_server_pass.sh
@@ -45,6 +45,7 @@ fn_printinfonl "Starting server with new password"
 command_start.sh
 # Stop server in "new password mode"
 command_stop.sh
+ts3serverpass="0"
 fn_printoknl "Password applied"
 fn_scriptlog "New ServerAdmin password applied"
 sleep 1


### PR DESCRIPTION
Always start the server with inifile parameter to ensure right settings.
And reset the ts3serverpass variable so it won't restart the server again in new password mode.