### PR TITLE
Checks if "log" folder already exists

### DIFF
--- a/lgsm/functions/install_logs.sh
+++ b/lgsm/functions/install_logs.sh
@@ -13,12 +13,16 @@ if [ "${checklogs}" != "1" ]; then
 fi
 sleep 1
 # Create dir's for the script and console logs
-mkdir -v "${rootdir}/log"
-mkdir -v "${scriptlogdir}"
-touch "${scriptlog}"
-if [ -n "${consolelogdir}" ]; then
-	mkdir -v "${consolelogdir}"
-	touch "${consolelog}"
+if [ -d "${rootdir}/log" ]; then
+	fn_print_warning_nl "Log folders already exist!"
+else
+	mkdir -v "${rootdir}/log"
+	mkdir -v "${scriptlogdir}"
+	touch "${scriptlog}"
+	if [ -n "${consolelogdir}" ]; then
+		mkdir -v "${consolelogdir}"
+		touch "${consolelog}"
+	fi
 fi
 
 # If a server is source or goldsource, Teamspeak 3, Starbound, Project Zomhoid create a symbolic link to the game server logs.


### PR DESCRIPTION
If the folder does exist, just displays a warning. Otherwise, it creates the folders.

This just removes the standard bash error message from the user.