### PR TITLE
Ark server updates to enable the details command

### DIFF
--- a/ARKSurvivalEvolved/arkserver
+++ b/ARKSurvivalEvolved/arkserver
@@ -20,7 +20,7 @@ version="210516"
 emailalert="off"
 email="email@example.com"
 
-# Pushbullet 
+# Pushbullet
 # https://www.pushbullet.com/#settings
 pushbulletalert="off"
 pushbullettoken="accesstoken"
@@ -30,11 +30,17 @@ steamuser="anonymous"
 steampass=""
 
 # Start Variables
+servername="ark-server"
+port="7778"
+queryport="27015"
+rconport="32330"
+rconpassword="" # Set to enable rcon
+maxplayers="50"
 ip="0.0.0.0"
 updateonstart="off"
 
 fn_parms(){
-parms="TheIsland?listen"
+    parms="TheIsland?listen?MultiHome=${ip}?SessionName=${servername}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port}?ServerAdminPassword=${rconpassword}"
 }
 
 #### Advanced Variables ####

--- a/BrainBread2/bb2server
+++ b/BrainBread2/bb2server
@@ -9,7 +9,7 @@ if [ -f ".dev-debug" ]; then
 	set -x
 fi
 
-version="210516"
+version="030616"
 
 #### Variables ####
 
@@ -58,7 +58,7 @@ githubrepo="linuxgsm"
 githubbranch="master"
 
 # Steam
-appid="346330"
+appid="475370"
 
 # Server Details
 servicename="bb2-server"

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -2,7 +2,7 @@
 # LGSM check_deps.sh function
 # Author: Daniel Gibbs
 # Website: https://gameservermanagers.com
-lgsm_version="270516"
+lgsm_version="090616"
 
 # Description: Checks that the requires dependencies are installed for LGSM.
 
@@ -126,7 +126,6 @@ if [ -n "$(command -v dpkg-query)" ]; then
 	array_deps_missing=()
 
 	# LGSM requirement for curl
-	array_deps_required=( curl ca-certificates file )
 
 	# All servers except ts3 require tmux
 	if [ "${executable}" != "./ts3server_startscript.sh" ]; then
@@ -176,7 +175,6 @@ elif [ -n "$(command -v yum)" ]; then
 	array_deps_missing=()
 
 	# LGSM requirement for curl
-	array_deps_required=( curl )
 
 	# All servers except ts3 require tmux
 	if [ "${executable}" != "./ts3server_startscript.sh" ]; then

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -126,6 +126,7 @@ if [ -n "$(command -v dpkg-query)" ]; then
 	array_deps_missing=()
 
 	# LGSM requirement for curl
+	array_deps_required=( curl ca-certificates file bsdmainutils python )
 
 	# All servers except ts3 require tmux
 	if [ "${executable}" != "./ts3server_startscript.sh" ]; then
@@ -175,6 +176,7 @@ elif [ -n "$(command -v yum)" ]; then
 	array_deps_missing=()
 
 	# LGSM requirement for curl
+	array_deps_required=( curl util-linux python file )
 
 	# All servers except ts3 require tmux
 	if [ "${executable}" != "./ts3server_startscript.sh" ]; then

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -2,7 +2,7 @@
 # LGSM check_deps.sh function
 # Author: Daniel Gibbs
 # Website: https://gameservermanagers.com
-lgsm_version="210516"
+lgsm_version="270516"
 
 # Description: Checks that the requires dependencies are installed for LGSM.
 
@@ -126,7 +126,7 @@ if [ -n "$(command -v dpkg-query)" ]; then
 	array_deps_missing=()
 
 	# LGSM requirement for curl
-	array_deps_required=( curl ca-certificates )
+	array_deps_required=( curl ca-certificates file )
 
 	# All servers except ts3 require tmux
 	if [ "${executable}" != "./ts3server_startscript.sh" ]; then

--- a/lgsm/functions/command_details.sh
+++ b/lgsm/functions/command_details.sh
@@ -288,7 +288,7 @@ fn_details_ports(){
 		fi
 	done
 
-	local ports_edit_array=( "starbound" "spark" "source" "goldsource" "Rust" "Hurtworld" )
+	local ports_edit_array=( "starbound" "spark" "source" "goldsource" "Rust" "Hurtworld" "unreal4")
 	for port_edit in "${ports_edit_array[@]}"
 	do
 		if [ "${engine}" == "${port_edit}" ]||[ "${gamename}" == "${port_edit}" ]; then

--- a/lgsm/functions/command_fastdl.sh
+++ b/lgsm/functions/command_fastdl.sh
@@ -3,7 +3,7 @@
 # Author: Daniel Gibbs
 # Contributor: UltimateByte
 # Website: https://gameservermanagers.com
-lgsm_version="210216"
+lgsm_version="060616"
 
 # Description: Creates a FastDL folder
 
@@ -59,7 +59,7 @@ fn_fastdl_init(){
 		fn_print_info "Creating FastDL directories"
 		echo -en "\n"
 		sleep 1
-		fn_printdots "Creating www directory"
+		fn_print_dots "Creating www directory"
 		sleep 0.5
 		mkdir "${webdir}"
 		fn_print_ok "Created www directory"
@@ -70,7 +70,7 @@ fn_fastdl_init(){
 	if [ ! -d "${fastdldir}" ]; then
 		# No folder, won't ask for removing old ones
 		newfastdl=1
-		fn_printdots "Creating fastdl directory"
+		fn_print_dots "Creating fastdl directory"
 		sleep 0.5
 		mkdir "${fastdldir}"
 		fn_print_ok "Created fastdl directory"
@@ -91,7 +91,7 @@ fn_fastdl_config(){
 	echo -en "\n"
 	# Prompt for clearing old files if folder was already here
 	if [ -n "${newfastdl}" ] && [ "${newfastdl}" == "0" ]; then
-		fn_printdots
+		fn_print_dots
 		while true; do
 			read -e -i "y" -p "Clear old FastDL files? [Y/n]" yn
 			case $yn in
@@ -104,7 +104,7 @@ fn_fastdl_config(){
 	fi
 	# Prompt for using bzip2 if it's installed
 	if [ ${bzip2installed} == 1 ]; then
-		fn_printdots
+		fn_print_dots
 		while true; do
 			read -e -i "y" -p "Enable file compression using bzip2? [Y/n]" yn
 			case $yn in
@@ -119,7 +119,7 @@ fn_fastdl_config(){
 
 fn_fastdl_gmod_config(){
 	# Prompt for download enforcer, that is using a .lua addfile resource generator
-	fn_printdots
+	fn_print_dots
 	while true; do
 		read -e -i "y" -p "Use client download enforcer? [Y/n]" yn
 		case $yn in
@@ -148,7 +148,7 @@ fn_clear_old_fastdl(){
 fn_gmod_fastdl(){
 	# Copy all needed files for FastDL
 	echo ""
-	fn_printdots "Starting gathering all needed files"
+	fn_print_dots "Starting gathering all needed files"
 	fn_scriptlog "Starting gathering all needed files"
 	sleep 1
 	echo -en "\n"
@@ -157,7 +157,7 @@ fn_gmod_fastdl(){
 	cd "${systemdir}"
 
 	# Map Files
-	fn_printdots "Copying map files..."
+	fn_print_dots "Copying map files..."
 	fn_scriptlog "Copying map files"
 	sleep 0.5
 	find . -name '*.bsp' | cpio --quiet -updm "${fastdldir}"
@@ -166,7 +166,7 @@ fn_gmod_fastdl(){
 	echo -en "\n"
 
 	# Materials
-	fn_printdots "Copying materials..."
+	fn_print_dots "Copying materials..."
 	fn_scriptlog "Copying materials"
 	sleep 0.5
 	find . -name '*.vtf' | cpio --quiet -updm "${fastdldir}"
@@ -176,7 +176,7 @@ fn_gmod_fastdl(){
 	echo -en "\n"
 
 	# Models
-	fn_printdots "Copying models..."
+	fn_print_dots "Copying models..."
 	fn_scriptlog "Copying models"
 	sleep 1
 	find . -name '*.vtx' | cpio --quiet -updm "${fastdldir}"
@@ -188,7 +188,7 @@ fn_gmod_fastdl(){
 	echo -en "\n"
 
 	# Particles
-	fn_printdots "Copying particles..."
+	fn_print_dots "Copying particles..."
 	fn_scriptlog "Copying particles"
 	sleep 0.5
 	find . -name '*.pcf' | cpio --quiet -updm "${fastdldir}"
@@ -197,7 +197,7 @@ fn_gmod_fastdl(){
 	echo -en "\n"
 
 	# Sounds
-	fn_printdots "Copying sounds..."
+	fn_print_dots "Copying sounds..."
 	fn_scriptlog "Copying sounds"
 	sleep 0.5
 	find . -name '*.wav' | cpio --quiet -updm "${fastdldir}"
@@ -208,7 +208,7 @@ fn_gmod_fastdl(){
 	echo -en "\n"
 
 	# Resources (mostly fonts)
-	fn_printdots "Copying fonts and png..."
+	fn_print_dots "Copying fonts and png..."
 	fn_scriptlog "Copying fonts and png"
 	sleep 1
 	find . -name '*.otf' | cpio --quiet -updm "${fastdldir}"
@@ -235,7 +235,7 @@ fn_gmod_fastdl(){
 
 	# Correct content that may be into a lua folder by mistake like some darkrpmodification addons
 	if [ -d "${fastdldir}/lua" ]; then
-		fn_printdots "Typical DarkRP shit detected, fixing"
+		fn_print_dots "Typical DarkRP shit detected, fixing"
 		sleep 2
 		cp -Rf "${fastdldir}/lua/"* "${fastdldir}"
 		fn_print_ok "Stupid DarkRP file structure fixed"
@@ -250,7 +250,7 @@ fn_lua_fastdl(){
 	echo ""
 	if [ "${luaressource}" == "off" ]; then
 		if [ -f "${luafastdlfullpath}" ]; then
-			fn_printdots "Removing download enforcer"
+			fn_print_dots "Removing download enforcer"
 			sleep 1
 			rm -R "${luafastdlfullpath:?}"
 			fn_print_ok "Removed download enforcer"
@@ -262,7 +262,7 @@ fn_lua_fastdl(){
 	# Remove old lua file and generate a new one if user said yes
 	if [ "${luaressource}" == "on" ]; then
 		if [ -f "${luafastdlfullpath}" ]; then
-			fn_printdots "Removing old download enforcer"
+			fn_print_dots "Removing old download enforcer"
 			sleep 1
 			rm "${luafastdlfullpath}"
 			fn_print_ok "Removed old download enforcer"
@@ -270,7 +270,7 @@ fn_lua_fastdl(){
 			echo -en "\n"
 			sleep 1
 		fi
-		fn_printdots "Generating new download enforcer"
+		fn_print_dots "Generating new download enforcer"
 		fn_scriptlog "Generating new download enforcer"
 		sleep 1
 		# Read all filenames and put them into a lua file at the right path
@@ -292,7 +292,7 @@ fn_fastdl_bzip2(){
 		fn_print_info "Have a break, this step could take a while..."
 		echo -en "\n"
 		echo ""
-		fn_printdots "Compressing files using bzip2..."
+		fn_print_dots "Compressing files using bzip2..."
 		fn_scriptlog "Compressing files using bzip2..."
 		# bzip2 all files that are not already compressed (keeping original files)
 		find "${fastdldir}" \( -type f ! -name "*.bz2" \) -exec bzip2 -qk \{\} \;

--- a/lgsm/functions/command_fastdl.sh
+++ b/lgsm/functions/command_fastdl.sh
@@ -25,7 +25,7 @@ fn_check_bzip2(){
 	# Returns true if not installed
 	if [ -z "$(command -v bzip2)" ]; then
 		bzip2installed="0"
-		fn_printinfo "bzip2 is not installed !"
+		fn_print_info "bzip2 is not installed !"
 		fn_scriptlog "bzip2 is not installed"
 		echo -en "\n"
 		sleep 1
@@ -39,7 +39,7 @@ fn_check_bzip2(){
 
 fn_fastdl_init(){
 	# User confirmation
-	fn_printok "Welcome to LGSM's FastDL generator"
+	fn_print_ok "Welcome to LGSM's FastDL generator"
 	sleep 1
 	echo -en "\n"
 	fn_scriptlog "Started FastDL creation"
@@ -56,13 +56,13 @@ fn_fastdl_init(){
 	# Check and create folders
 	if [ ! -d "${webdir}" ]; then
 		echo ""
-		fn_printinfo "Creating FastDL directories"
+		fn_print_info "Creating FastDL directories"
 		echo -en "\n"
 		sleep 1
 		fn_printdots "Creating www directory"
 		sleep 0.5
 		mkdir "${webdir}"
-		fn_printok "Created www directory"
+		fn_print_ok "Created www directory"
 		fn_scriptlog "FastDL created www directory"
 		sleep 1
 		echo -en "\n"
@@ -73,7 +73,7 @@ fn_fastdl_init(){
 		fn_printdots "Creating fastdl directory"
 		sleep 0.5
 		mkdir "${fastdldir}"
-		fn_printok "Created fastdl directory"
+		fn_print_ok "Created fastdl directory"
 		fn_scriptlog "FastDL created fastdl directory"
 		sleep 1
 		echo -en "\n"
@@ -85,7 +85,7 @@ fn_fastdl_init(){
 
 fn_fastdl_config(){
 	# Global settings for FastDL creation
-	fn_printinfo "Entering configuration"
+	fn_print_info "Entering configuration"
 	fn_scriptlog "Configuration"
 	sleep 2
 	echo -en "\n"
@@ -95,8 +95,8 @@ fn_fastdl_config(){
 		while true; do
 			read -e -i "y" -p "Clear old FastDL files? [Y/n]" yn
 			case $yn in
-			[Yy]* ) clearoldfastdl="on"; fn_scriptlog "clearoldfastdl enabled"; fn_printok "Clearing Enabled"; break;;
-			[Nn]* ) clearoldfastdl="off"; fn_scriptlog "clearoldfastdl disabled"; fn_printok "Clearing Disabled"; break;;
+			[Yy]* ) clearoldfastdl="on"; fn_scriptlog "clearoldfastdl enabled"; fn_print_ok "Clearing Enabled"; break;;
+			[Nn]* ) clearoldfastdl="off"; fn_scriptlog "clearoldfastdl disabled"; fn_print_ok "Clearing Disabled"; break;;
 			* ) echo "Please answer yes or no.";;
 			esac
 		done
@@ -108,8 +108,8 @@ fn_fastdl_config(){
 		while true; do
 			read -e -i "y" -p "Enable file compression using bzip2? [Y/n]" yn
 			case $yn in
-			[Yy]* ) bzip2enable="on"; fn_scriptlog "bzip2 enabled"; fn_printok "bzip2 Enabled"; break;;
-			[Nn]* ) bzip2enable="off"; fn_scriptlog "bzip2 disabled"; fn_printok "bzip2 Disabled"; break;;
+			[Yy]* ) bzip2enable="on"; fn_scriptlog "bzip2 enabled"; fn_print_ok "bzip2 Enabled"; break;;
+			[Nn]* ) bzip2enable="off"; fn_scriptlog "bzip2 disabled"; fn_print_ok "bzip2 Disabled"; break;;
 			* ) echo "Please answer yes or no.";;
 			esac
 		done
@@ -123,8 +123,8 @@ fn_fastdl_gmod_config(){
 	while true; do
 		read -e -i "y" -p "Use client download enforcer? [Y/n]" yn
 		case $yn in
-		[Yy]* ) luaressource="on"; fn_scriptlog "DL enforcer Enabled"; fn_printok "Enforcer Enabled"; break;;
-		[Nn]* ) luaressource="off"; fn_scriptlog "DL enforcer Disabled"; fn_printok "Enforcer Disabled"; break;;
+		[Yy]* ) luaressource="on"; fn_scriptlog "DL enforcer Enabled"; fn_print_ok "Enforcer Enabled"; break;;
+		[Nn]* ) luaressource="off"; fn_scriptlog "DL enforcer Disabled"; fn_print_ok "Enforcer Disabled"; break;;
 		* ) echo "Please answer yes or no.";;
 		esac
 	done
@@ -134,11 +134,11 @@ fn_fastdl_gmod_config(){
 fn_clear_old_fastdl(){
 	# Clearing old FastDL if user answered yes
 	if [ "${clearoldfastdl}" == "on" ]; then
-		fn_printinfo "Clearing existing FastDL folder"
+		fn_print_info "Clearing existing FastDL folder"
 		fn_scriptlog "Clearing existing FastDL folder"
 		sleep 0.5
 		rm -R "${fastdldir:?}"/*
-		fn_printok "Old FastDL folder cleared"
+		fn_print_ok "Old FastDL folder cleared"
 		fn_scriptlog "Old FastDL folder cleared"
 		sleep 1
 		echo -en "\n"
@@ -161,7 +161,7 @@ fn_gmod_fastdl(){
 	fn_scriptlog "Copying map files"
 	sleep 0.5
 	find . -name '*.bsp' | cpio --quiet -updm "${fastdldir}"
-	fn_printok "Map files copied"
+	fn_print_ok "Map files copied"
 	sleep 0.5
 	echo -en "\n"
 
@@ -171,7 +171,7 @@ fn_gmod_fastdl(){
 	sleep 0.5
 	find . -name '*.vtf' | cpio --quiet -updm "${fastdldir}"
 	find . -name '*.vmt' | cpio --quiet -updm "${fastdldir}"
-	fn_printok "Materials copied"
+	fn_print_ok "Materials copied"
 	sleep 0.5
 	echo -en "\n"
 
@@ -183,7 +183,7 @@ fn_gmod_fastdl(){
 	find . -name '*.vvd' | cpio --quiet -updm "${fastdldir}"
 	find . -name '*.mdl' | cpio --quiet -updm "${fastdldir}"
 	find . -name '*.phy' | cpio --quiet -updm "${fastdldir}"
-	fn_printok "Models copied"
+	fn_print_ok "Models copied"
 	sleep 0.5
 	echo -en "\n"
 
@@ -192,7 +192,7 @@ fn_gmod_fastdl(){
 	fn_scriptlog "Copying particles"
 	sleep 0.5
 	find . -name '*.pcf' | cpio --quiet -updm "${fastdldir}"
-	fn_printok "Particles copied"
+	fn_print_ok "Particles copied"
 	sleep 0.5
 	echo -en "\n"
 
@@ -203,7 +203,7 @@ fn_gmod_fastdl(){
 	find . -name '*.wav' | cpio --quiet -updm "${fastdldir}"
 	find . -name '*.mp3' | cpio --quiet -updm "${fastdldir}"
 	find . -name '*.ogg' | cpio --quiet -updm "${fastdldir}"
-	fn_printok "Sounds copied"
+	fn_print_ok "Sounds copied"
 	sleep 0.5
 	echo -en "\n"
 
@@ -214,7 +214,7 @@ fn_gmod_fastdl(){
 	find . -name '*.otf' | cpio --quiet -updm "${fastdldir}"
 	find . -name '*.ttf' | cpio --quiet -updm "${fastdldir}"
 	find . -name '*.png' | cpio --quiet -updm "${fastdldir}"
-	fn_printok "Fonts and png copied"
+	fn_print_ok "Fonts and png copied"
 	sleep 0.5
 	echo -en "\n"
 
@@ -223,12 +223,12 @@ fn_gmod_fastdl(){
 
 	# Correct addons folder structure for FastDL
 	if [ -d "${fastdldir}/addons" ]; then
-		fn_printinfo "Adjusting addons' file structure"
+		fn_print_info "Adjusting addons' file structure"
 		fn_scriptlog "Adjusting addon's file structure"
 		sleep 1
 		cp -Rf "${fastdldir}"/addons/*/* "${fastdldir}"
 	#Don't remove yet	rm -R "${fastdldir:?}/addons"
-		fn_printok "Adjusted addon's file structure"
+		fn_print_ok "Adjusted addon's file structure"
 		sleep 1
 		echo -en "\n"
 	fi
@@ -238,7 +238,7 @@ fn_gmod_fastdl(){
 		fn_printdots "Typical DarkRP shit detected, fixing"
 		sleep 2
 		cp -Rf "${fastdldir}/lua/"* "${fastdldir}"
-		fn_printok "Stupid DarkRP file structure fixed"
+		fn_print_ok "Stupid DarkRP file structure fixed"
 		sleep 2
 		echo -en "\n"
 	fi
@@ -253,7 +253,7 @@ fn_lua_fastdl(){
 			fn_printdots "Removing download enforcer"
 			sleep 1
 			rm -R "${luafastdlfullpath:?}"
-			fn_printok "Removed download enforcer"
+			fn_print_ok "Removed download enforcer"
 			fn_scriptlog "Removed old download inforcer"
 			echo -en "\n"
 			sleep 2
@@ -265,7 +265,7 @@ fn_lua_fastdl(){
 			fn_printdots "Removing old download enforcer"
 			sleep 1
 			rm "${luafastdlfullpath}"
-			fn_printok "Removed old download enforcer"
+			fn_print_ok "Removed old download enforcer"
 			fn_scriptlog "Removed old download enforcer"
 			echo -en "\n"
 			sleep 1
@@ -277,7 +277,7 @@ fn_lua_fastdl(){
 		find "${fastdldir}" \( -type f ! -name "*.bz2" \) -printf '%P\n' | while read line; do
 			echo "resource.AddFile( "\""${line}"\"" )" >> ${luafastdlfullpath}
 		done
-		fn_printok "Download enforcer generated"
+		fn_print_ok "Download enforcer generated"
 		fn_scriptlog "Download enforcer generated"
 		echo -en "\n"
 		echo ""
@@ -289,14 +289,14 @@ fn_fastdl_bzip2(){
 	# Compressing using bzip2 if user said yes
 	echo ""
 	if [ ${bzip2enable} == "on" ]; then
-		fn_printinfo "Have a break, this step could take a while..."
+		fn_print_info "Have a break, this step could take a while..."
 		echo -en "\n"
 		echo ""
 		fn_printdots "Compressing files using bzip2..."
 		fn_scriptlog "Compressing files using bzip2..."
 		# bzip2 all files that are not already compressed (keeping original files)
 		find "${fastdldir}" \( -type f ! -name "*.bz2" \) -exec bzip2 -qk \{\} \;
-		fn_printok "bzip2 compression done"
+		fn_print_ok "bzip2 compression done"
 		fn_scriptlog "bzip2 compression done"
 		sleep 1
 		echo -en "\n"
@@ -306,12 +306,12 @@ fn_fastdl_bzip2(){
 fn_fastdl_completed(){
 	# Finished message
 	echo ""
-	fn_printok "Congratulations, it's done !"
+	fn_print_ok "Congratulations, it's done !"
 	fn_scriptlog "FastDL job done"
 	sleep 2
 	echo -en "\n"
 	echo ""
-	fn_printinfo "Need more doc ? See https://github.com/dgibbs64/linuxgsm/wiki/FastDL"
+	fn_print_info "Need more doc ? See https://github.com/dgibbs64/linuxgsm/wiki/FastDL"
 	echo -en "\n"
 	if [ "$bzip2installed" == "0" ]; then
 	echo "By the way, you'd better install bzip2 an re-run this command !"

--- a/lgsm/functions/fix_ins.sh
+++ b/lgsm/functions/fix_ins.sh
@@ -8,7 +8,7 @@ lgsm_version="210516"
 
 # Resolves ./srcds_linux: error while loading shared libraries: libtier0.so: cannot open shared object file: No such file or directory
 
-export LD_LIBRARY_PATH=:${filesdir}:${filesdir}/bin:{$LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${filesdir}:${filesdir}/bin:${LD_LIBRARY_PATH}
 
 # fix for issue #529 - gamemode not passed to debug or start
 

--- a/lgsm/functions/update_check.sh
+++ b/lgsm/functions/update_check.sh
@@ -169,7 +169,7 @@ fn_steamcmdcheck(){
 		fn_scriptlog "${currentbuild} > ${availablebuild}"
 
 		unset updateonstart
-		info_status.sh
+		check_status.sh
 		if [ "${status}" != "0" ]; then
 			command_stop.sh
 			update_dl.sh


### PR DESCRIPTION
Ref #844 and the original pull request #770 from @yadutaf

Ark does not seem to honor parameters in GameUserSettings.ini.  This change sets them in the script instead, where it does affect the actual runtime game parameters (QueryPort, for example).

Setting the parameters in the script then also addresses another unresolved issue in the ./arkserver details" output - which currently fails because arkserver's engine isn't aligned with either selfname or configfile paradigm in command_details.sh

Declaring the game parameters in the script allows arserver to fall in the ${selfname} category for parameters in the details command.  Looking at the scripts, Ark seems to be the only unreal4 engine, so it (unreal4) was added to the corresponding ports_edit_array for those games that fall under the ${selfname} paradigm for pulling the parameters.