### PR TITLE
Comment and default map settings cleanup.

### DIFF
--- a/Rust/rustserver
+++ b/Rust/rustserver
@@ -42,7 +42,7 @@ maxplayers="50"
 
 # Advanced
 seed="" #  default random; range : 1 to 2147483647 ; used to change or reproduce a procedural map
-worldsize="4000" # default 4000; range : 2000 to 8000 ; map size in meters
+worldsize="4000" # default 4000; range : 2000 to 6000 ; map size in meters
 saveinterval="300" # Auto-save in seconds
 tickrate="30" # default 30; range : 15 to 100
 

--- a/Rust/rustserver
+++ b/Rust/rustserver
@@ -41,7 +41,7 @@ rconpassword="CHANGE_ME"
 maxplayers="50"
 
 # Advanced
-seed="" #  default random; range : -2147483647 to 2147483647 ; used to change or reproduce a procedural map
+seed="" #  default random; range : 1 to 2147483647 ; used to change or reproduce a procedural map
 worldsize="4000" # default 4000; range : 2000 to 8000 ; map size in meters
 saveinterval="300" # Auto-save in seconds
 tickrate="30" # default 30; range : 15 to 100

--- a/Rust/rustserver
+++ b/Rust/rustserver
@@ -42,7 +42,7 @@ maxplayers="50"
 
 # Advanced
 seed="" #  default random; range : 1 to 2147483647 ; used to change or reproduce a procedural map
-worldsize="3000" # default 3000; range : 2000 to 6000 ; map size in meters
+worldsize="3000" # default 3000; range : 1000 to 6000 ; map size in meters
 saveinterval="300" # Auto-save in seconds
 tickrate="30" # default 30; range : 15 to 100
 

--- a/Rust/rustserver
+++ b/Rust/rustserver
@@ -42,7 +42,7 @@ maxplayers="50"
 
 # Advanced
 seed="" #  default random; range : 1 to 2147483647 ; used to change or reproduce a procedural map
-worldsize="4000" # default 4000; range : 2000 to 6000 ; map size in meters
+worldsize="3000" # default 3000; range : 2000 to 6000 ; map size in meters
 saveinterval="300" # Auto-save in seconds
 tickrate="30" # default 30; range : 15 to 100
 


### PR DESCRIPTION
Some of the map settings have different ranges or they've changed in recent updates to Rust. I've cleaned up the settings and adjusted the comments as required.