### PR TITLE
Add ${branch} to validate

### DIFF
--- a/lgsm/functions/command_validate.sh
+++ b/lgsm/functions/command_validate.sh
@@ -29,7 +29,7 @@ fn_validation(){
 	if [ "${engine}" == "goldsource" ]; then
 		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" +app_update "${appid}" validate +quit| tee -a "${scriptlog}"
 	else
-		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" validate +quit| tee -a "${scriptlog}"
+		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} validate +quit| tee -a "${scriptlog}"
 	fi
 
 	fix.sh


### PR DESCRIPTION
It's useful to use ${branch} to set beta builds, its avaliable on the install command but missing in the validate command here. This is already used in a validate call in the install command.