### PR TITLE
Changed the order of game mode variables

### DIFF
--- a/CounterStrikeGlobalOffensive/csgoserver
+++ b/CounterStrikeGlobalOffensive/csgoserver
@@ -37,8 +37,8 @@ steampass=""
 # Classic Competitive        0            1
 # Demolition                 1            1
 # Deathmatch                 1            2
-gamemode="0"
 gametype="0"
+gamemode="0"
 defaultmap="de_dust2"
 mapgroup="random_classic"
 maxplayers="16"


### PR DESCRIPTION
To avoid possible confusion like in #900. The old order encouraged the mix up of "gametype" and "gamemode".