### PR TITLE
Fixing the issue when the process id vanishes.

### DIFF
--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -180,6 +180,7 @@ fn_stop_ark(){
                                 rev | cut -d\/ -f1)
                         #
                         # check for a valid pid
+                        pig=${pid//[!0-9]/}
                         let pid+=0 # turns an empty string into a valid number, '0',
                         # and a valid numeric pid remains unchanged.
                         if [[ $pid -gt 1 && $pid -le $(cat /proc/sys/kernel/pid_max) ]] ; then

--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -180,7 +180,7 @@ fn_stop_ark(){
                                 rev | cut -d\/ -f1)
                         #
                         # check for a valid pid
-                        pig=${pid//[!0-9]/}
+                        pid=${pid//[!0-9]/}
                         let pid+=0 # turns an empty string into a valid number, '0',
                         # and a valid numeric pid remains unchanged.
                         if [[ $pid -gt 1 && $pid -le $(cat /proc/sys/kernel/pid_max) ]] ; then


### PR DESCRIPTION
Cleans up any non-digit returned in the resulting process id query when the process has terminated.

In the event the process id vanishes, the "let" command in the subsequent line sets the value to 0 (which was the intended result when no process id was found).