### PR TITLE
Raminfo

### DIFF
--- a/lgsm/functions/command_details.sh
+++ b/lgsm/functions/command_details.sh
@@ -42,8 +42,8 @@ fn_details_performance(){
 	# Uptime:    55d, 3h, 38m
 	# Avg Load:  1.00, 1.01, 0.78
 	#
-	# Mem:       total   used   free
-	# Physical:  741M    656M   85M
+	# Mem:       total   used   free  cached
+	# Physical:  741M    656M   85M   256M 
 	# Swap:      0B      0B     0B
 
 	echo -e ""
@@ -55,8 +55,8 @@ fn_details_performance(){
 	} | column -s $'\t' -t
 	echo -e ""
 	{
-		echo -e "${blue}Mem:\t${blue}total\t used\t free${default}"
-		echo -e "${blue}Physical:\t${default}${physmemtotal}\t${physmemused}\t${physmemfree}${default}"
+		echo -e "${blue}Mem:\t${blue}total\t used\t free\t cached${default}"
+		echo -e "${blue}Physical:\t${default}${physmemtotal}\t${physmemused}\t${physmemfree}\t${physmemcached}${default}"
 		echo -e "${blue}Swap:\t${default}${swaptotal}\t${swapused}\t${swapfree}${default}"
 	} | column -s $'\t' -t
 }

--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -63,6 +63,7 @@ fi
 physmemtotal=$(free ${humanreadable} | awk '/Mem:/ {print $2}')
 physmemused=$(free ${humanreadable} | awk '/Mem:/ {print $3}')
 physmemfree=$(free ${humanreadable} | awk '/Mem:/ {print $4}')
+pysmemcached=$(free ${humanreadable} | awk '/cache:/ {print $4}')
 swaptotal=$(free ${humanreadable} | awk '/Swap:/ {print $2}')
 swapused=$(free ${humanreadable} | awk '/Swap:/ {print $3}')
 swapfree=$(free ${humanreadable} | awk '/Swap:/ {print $4}')

--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -63,7 +63,7 @@ fi
 physmemtotal=$(free ${humanreadable} | awk '/Mem:/ {print $2}')
 physmemused=$(free ${humanreadable} | awk '/Mem:/ {print $3}')
 physmemfree=$(free ${humanreadable} | awk '/Mem:/ {print $4}')
-pysmemcached=$(free ${humanreadable} | awk '/cache:/ {print $4}')
+physmemcached=$(free ${humanreadable} | awk '/cache:/ {print $4}')
 swaptotal=$(free ${humanreadable} | awk '/Swap:/ {print $2}')
 swapused=$(free ${humanreadable} | awk '/Swap:/ {print $3}')
 swapfree=$(free ${humanreadable} | awk '/Swap:/ {print $4}')


### PR DESCRIPTION
Well, i added cached RAM info, if available it'll be displayed, otherwise not as awk will not be able to find "cache:" without returning any error.
Will work for most standard distros. 
However, the "cached" column will appear in any case as i didn't make an "if" function for that.
http://image.noelshack.com/fichiers/2016/30/1469548642-cached-info.png

#862