### PR TITLE
RCON password check for Rust

### DIFF
--- a/lgsm/functions/check_config.sh
+++ b/lgsm/functions/check_config.sh
@@ -18,20 +18,22 @@ if [ ! -e "${servercfgfullpath}" ]; then
 		sleep 2
 	fi
 fi
+
 if [ "${gamename}" == "Rust" ]; then
-        if  [ -z "${rconpassword}" ]; then
-                fn_print_dots ""
-                sleep 0.5
-                fn_print_warn_nl "RCON password not set!"
-                echo "This would lead to unexpected behavior. Aborting."
-                fn_script_log_warn "No RCON Password set, exitting!"
-                exit 1
-        elif [ "${rconpassword}" == "CHANGE_ME" ]; then
-                fn_print_dots ""
-                sleep 0.5
-                fn_print_warn_nl "Default RCON Password detected!"
-                echo "Having CHANGE_ME as a passowrd is not very safe."
-                fn_script_log_warn "RCON Password is the default one!"
-                sleep 2
-        fi
+	if  [ -z "${rconpassword}" ]; then
+		fn_print_dots ""
+		sleep 0.5
+		fn_print_fail_nl "RCON password is not set!"
+		echo "  * Not setting an RCON password causes issues with ${gamename}"
+		fn_script_log_fatal "RCON password is not set"
+		fn_script_log_fatal "Not setting an RCON password causes issues with ${gamename}"
+		core_exit.sh
+	elif [ "${rconpassword}" == "CHANGE_ME" ]; then
+		fn_print_dots ""
+		sleep 0.5
+		fn_print_warn_nl "Default RCON Password detected!"
+		echo " * Having ${rconpassword} as a password is not very safe."
+		fn_script_log_warn "Default RCON Password detected"
+		sleep 2
+	fi
 fi

--- a/lgsm/functions/check_config.sh
+++ b/lgsm/functions/check_config.sh
@@ -18,3 +18,20 @@ if [ ! -e "${servercfgfullpath}" ]; then
 		sleep 2
 	fi
 fi
+if [ "${gamename}" == "Rust" ]; then
+        if  [ -z "${rconpassword}" ]; then
+                fn_print_dots ""
+                sleep 0.5
+                fn_print_warn_nl "RCON password not set!"
+                echo "This would lead to unexpected behavior. Aborting."
+                fn_script_log_warn "No RCON Password set, exitting!"
+                exit 1
+        elif [ "${rconpassword}" == "CHANGE_ME" ]; then
+                fn_print_dots ""
+                sleep 0.5
+                fn_print_warn_nl "Default RCON Password detected!"
+                echo "Having CHANGE_ME as a passowrd is not very safe."
+                fn_script_log_warn "RCON Password is the default one!"
+                sleep 2
+        fi
+fi


### PR DESCRIPTION
If no RCON password is set, it completely messes up with Rust.
If the default password is set, the admin should be warned as it's quite dangerous.

Tested: working as expected.

Fixes #848