### PR TITLE
System requirements

### DIFF
--- a/lgsm/functions/check.sh
+++ b/lgsm/functions/check.sh
@@ -83,3 +83,11 @@ do
 		check_status.sh
 	fi
 done
+
+local allowed_commands_array=( command_install.sh command_start.sh command_debug.sh )
+for allowed_command in "${allowed_commands_array[@]}"
+do
+	if [ "${allowed_command}" == "${function_selfname}" ]; then
+		check_system_requirements.sh
+	fi
+done

--- a/lgsm/functions/check_system_requirements.sh
+++ b/lgsm/functions/check_system_requirements.sh
@@ -3,24 +3,26 @@
 # Author: Daniel Gibbs
 # Contributor: UltimateByte
 # Website: https://gameservermanagers.com
-# Description: Checks RAM requirement
+# Description: Checks RAM requirements
 
-mbphysmem=$(free -m | awk '/Mem:/ {print $2}')
+local commandname="CHECK"
+local function_selfname="$(basename $(readlink -f "${BASH_SOURCE[0]}"))"
 
-# RAM requirement in MegaBytes for each game or engine
+info_distro.sh
+
+# RAM requirements in megabytes for each game or engine.
 if [ "${gamename}" == "Rust" ]; then
-  ramrequirement="4000"
+	ramrequirementmb="4000"
+	ramrequirementgb="4"
 fi
 
-# If the game or engine has a minimum RAM Requirement, compare it to system's available RAM
+# If the game or engine has a minimum RAM Requirement, compare it to system's available RAM.
 if [ -n "${ramrequirement}" ]; then
-  if [ "${mbphysmem}" -lt "${ramrequirement}" ]; then
-    # Warn the user
-    fn_print_warn "Insufficient physical RAM: ${mbphysmem}MB available for ${ramrequirement}MB required."
-    sleep 2
-    echo ""
-    echo "You may encounter issues such as server lagging or shutting down unexpectedly."
-    sleep 0.5
-    fn_script_log_warn "Insufficient physical RAM: ${mbphysmem}MB available for ${ramrequirement}MB required."
-  fi
-fi  
+	if [ "${physmemtotalmb}" -lt "${ramrequirementmb}" ]; then
+		# Warn the user
+		fn_print_warn "Insufficient memory: ${ramrequirementgb}G required, ${physmemtotal} available"
+		sleep 1
+		fn_print_warning "You may experiance poor performance from your server"
+		sleep 1
+	fi
+fi

--- a/lgsm/functions/check_system_requirements.sh
+++ b/lgsm/functions/check_system_requirements.sh
@@ -18,6 +18,7 @@ if [ -n "${ramrequirement}" ]; then
     # Warn the user
     fn_print_warn "Insufficient physical RAM: ${mbphysmem}MB available for ${ramrequirement}MB required."
     sleep 2
+    echo ""
     echo "You may encounter issues such as server lagging or shutting down unexpectedly."
     sleep 0.5
     fn_script_log_warn "Insufficient physical RAM: ${mbphysmem}MB available for ${ramrequirement}MB required."

--- a/lgsm/functions/check_system_requirements.sh
+++ b/lgsm/functions/check_system_requirements.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# LGSM check_system_requirements.sh
+# Author: Daniel Gibbs
+# Contributor: UltimateByte
+# Website: https://gameservermanagers.com
+# Description: Checks RAM requirement
+
+mbphysmem=$(free -m | awk '/Mem:/ {print $2}')
+
+# RAM requirement in MegaBytes for each game or engine
+if [ "${gamename} == "Rust" ]; then
+  ramrequirement="4000"
+fi
+
+# If the game or engine has a minimum RAM Requirement, compare it to system's available RAM
+if [ -n "${ramrequirement}" ]; then
+  if [ "${mbphysmem}" -lt "${ramrequirement} ]; then
+    # Warn the user
+    fn_print_warn "Insufficient physical RAM: ${mbphysmem}MB available for ${ramrequirement}MB required."
+    echo "You may encounter issues such as server lagging or shutting down unexpectedly."
+    fn_script_log_warn "Insufficient physical RAM: ${mbphysmem}MB available for ${ramrequirement}MB required."
+  fi
+fi  

--- a/lgsm/functions/check_system_requirements.sh
+++ b/lgsm/functions/check_system_requirements.sh
@@ -14,7 +14,7 @@ fi
 
 # If the game or engine has a minimum RAM Requirement, compare it to system's available RAM
 if [ -n "${ramrequirement}" ]; then
-  if [ "${mbphysmem}" -lt "${ramrequirement}"" ]; then
+  if [ "${mbphysmem}" -lt "${ramrequirement}" ]; then
     # Warn the user
     fn_print_warn "Insufficient physical RAM: ${mbphysmem}MB available for ${ramrequirement}MB required."
     sleep 2

--- a/lgsm/functions/check_system_requirements.sh
+++ b/lgsm/functions/check_system_requirements.sh
@@ -17,7 +17,9 @@ if [ -n "${ramrequirement}" ]; then
   if [ "${mbphysmem}" -lt "${ramrequirement} ]; then
     # Warn the user
     fn_print_warn "Insufficient physical RAM: ${mbphysmem}MB available for ${ramrequirement}MB required."
+    sleep 2
     echo "You may encounter issues such as server lagging or shutting down unexpectedly."
+    sleep 0.5
     fn_script_log_warn "Insufficient physical RAM: ${mbphysmem}MB available for ${ramrequirement}MB required."
   fi
 fi  

--- a/lgsm/functions/check_system_requirements.sh
+++ b/lgsm/functions/check_system_requirements.sh
@@ -8,13 +8,13 @@
 mbphysmem=$(free -m | awk '/Mem:/ {print $2}')
 
 # RAM requirement in MegaBytes for each game or engine
-if [ "${gamename} == "Rust" ]; then
+if [ "${gamename}" == "Rust" ]; then
   ramrequirement="4000"
 fi
 
 # If the game or engine has a minimum RAM Requirement, compare it to system's available RAM
 if [ -n "${ramrequirement}" ]; then
-  if [ "${mbphysmem}" -lt "${ramrequirement} ]; then
+  if [ "${mbphysmem}" -lt "${ramrequirement}"" ]; then
     # Warn the user
     fn_print_warn "Insufficient physical RAM: ${mbphysmem}MB available for ${ramrequirement}MB required."
     sleep 2

--- a/lgsm/functions/core_functions.sh
+++ b/lgsm/functions/core_functions.sh
@@ -222,6 +222,11 @@ functionfile="${FUNCNAME}"
 fn_fetch_function
 }
 
+check_system_requirements.sh(){
+functionfile="${FUNCANME}"
+fn_fetch_function
+}
+
 check_tmux.sh(){
 functionfile="${FUNCNAME}"
 fn_fetch_function

--- a/lgsm/functions/core_functions.sh
+++ b/lgsm/functions/core_functions.sh
@@ -223,7 +223,7 @@ fn_fetch_function
 }
 
 check_system_requirements.sh(){
-functionfile="${FUNCANME}"
+functionfile="${FUNCNAME}"
 fn_fetch_function
 }
 

--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -61,12 +61,12 @@ else
 fi
 
 physmemtotal=$(free ${humanreadable} | awk '/Mem:/ {print $2}')
+physmemtotalmb=$(free -m | awk '/Mem:/ {print $2}')
 physmemused=$(free ${humanreadable} | awk '/Mem:/ {print $3}')
 physmemfree=$(free ${humanreadable} | awk '/Mem:/ {print $4}')
 swaptotal=$(free ${humanreadable} | awk '/Swap:/ {print $2}')
 swapused=$(free ${humanreadable} | awk '/Swap:/ {print $3}')
 swapfree=$(free ${humanreadable} | awk '/Swap:/ {print $4}')
-
 
 ### Disk Infomation
 


### PR DESCRIPTION
Added what we need to check system requirements, starting with RAM.
It will check RAM upon server install and start, and display a warning if not enough RAM is detected.
For now, only Rust has a RAM requirement set at 4000MB RAM.
It's now easy to add other games, or even HDD space check before server installation.

#847