### PR TITLE
Added directory check

### DIFF
--- a/lgsm/functions/check_permissions.sh
+++ b/lgsm/functions/check_permissions.sh
@@ -9,21 +9,23 @@ local commandname="CHECK"
 local function_selfname="$(basename $(readlink -f "${BASH_SOURCE[0]}"))"
 
 fn_check_ownership(){
-	if [ $(find "${filesdir}" -not -user $(whoami)|wc -l) -ne "0" ]||[ $(find "${rootdir}/${selfname}" -not -user $(whoami)|wc -l) -ne "0" ]; then
-		fn_print_fail_nl "Permissions issues found"
-		fn_script_log_fatal "Permissions issues found"
-		fn_print_infomation_nl "The current user ($(whoami)) does not have ownership of the following files:"
-		fn_script_log_info "The current user ($(whoami)) does not have ownership of the following files:"
-		{
-			echo -e "User\tGroup\tFile\n"
-			find "${filesdir}" -not -user $(whoami) -printf "%u\t\t%g\t%p\n"
-		} | column -s $'\t' -t | tee -a "${scriptlog}"
-		core_exit.sh
+	if [ -d "${filesdir}" ]; then
+		if [ $(find "${filesdir}" -not -user $(whoami)|wc -l) -ne "0" ]||[ $(find "${rootdir}/${selfname}" -not -user $(whoami)|wc -l) -ne "0" ]; then
+			fn_print_fail_nl "Permissions issues found"
+			fn_script_log_fatal "Permissions issues found"
+			fn_print_infomation_nl "The current user ($(whoami)) does not have ownership of the following files:"
+			fn_script_log_info "The current user ($(whoami)) does not have ownership of the following files:"
+			{
+				echo -e "User\tGroup\tFile\n"
+				find "${filesdir}" -not -user $(whoami) -printf "%u\t\t%g\t%p\n"
+			} | column -s $'\t' -t | tee -a "${scriptlog}"
+			core_exit.sh
+		fi
 	fi
 }
 
 fn_check_permissions(){
-	if [ -n "${functionsdir}" ]; then
+	if [ -d "${functionsdir}" ]; then
 		if [ $(find "${functionsdir}" -type f -not -executable|wc -l) -ne "0" ]; then
 			fn_print_fail_nl "Permissions issues found"
 			fn_script_log_fatal "Permissions issues found"


### PR DESCRIPTION
Fixes the error message when doing a fresh install.
e.g.:
```
~$ ./pzserver install
    fetching core_dl.sh...OK
    fetching core_functions.sh...OK
    fetching core_trap.sh...OK
    fetching core_messages.sh...OK
    fetching core_getopt.sh...OK
    fetching command_install.sh...OK
    fetching check.sh...OK
    fetching check_root.sh...OK
    fetching check_permissions.sh...OK
find: ‘/home/pzserver/serverfiles’: No such file or directory
    fetching check_glibc.sh...OK
    fetching info_glibc.sh...OK
    fetching info_distro.sh...OK
    fetching check_tmux.sh...OK
    fetching install_header.sh...OK
```

**Is there a reason to use**
`if [ -n "${functionsdir}" ]; then`
**over**
`if [ -d "${functionsdir}" ]; then`
**?** ([source](https://github.com/dgibbs64/linuxgsm/blob/master/lgsm/functions/check_permissions.sh#L26))

-n just checks if the string isn't empty and -d if the directory exists?