### PR TITLE
Added required dependencies to enable readline

### DIFF
--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -158,7 +158,7 @@ if [ -n "$(command -v dpkg-query)" ]; then
 	elif [ "${gamename}" ==  "7 Days To Die" ]; then
 		array_deps_required+=( telnet expect )
 	# No More Room in Hell
-	elif [ "${gamename}" == "No More Room in Hell" ]; then
+	elif [ "${gamename}" == "No More Room in Hell" ]||[ "${gamename}" == "Counter Strike: Source" ]||[ "${gamename}" == "Garry's Mod" ]; then
 		array_deps_required+=( lib32tinfo5 )
 	# Brainbread 2 and Don't Starve Together
 	elif [ "${gamename}" == "Brainbread 2" ]||[ "${gamename}" == "Don't Starve Together" ]; then
@@ -205,7 +205,7 @@ elif [ -n "$(command -v yum)" ]; then
 	elif [ "${gamename}" ==  "7 Days To Die" ]; then
 		array_deps_required+=( telnet expect )
 	# No More Room in Hell
-	elif [ "${gamename}" == "No More Room in Hell" ]; then
+	elif [ "${gamename}" == "No More Room in Hell" ]||[ "${gamename}" == "Counter Strike: Source" ]||[ "${gamename}" == "Garry's Mod" ]; then
 		array_deps_required+=( ncurses-libs.i686 )
 	# Brainbread 2 and Don't Starve Together
 	elif [ "${gamename}" == "Brainbread 2" ]||[ "${gamename}" == "Don't Starve Together" ]; then

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -157,7 +157,7 @@ if [ -n "$(command -v dpkg-query)" ]; then
 	# 7 Days to Die
 	elif [ "${gamename}" ==  "7 Days To Die" ]; then
 		array_deps_required+=( telnet expect )
-	# No More Room in Hell
+	# No More Room in Hell, Counter Strike: Source and Garry's Mod
 	elif [ "${gamename}" == "No More Room in Hell" ]||[ "${gamename}" == "Counter Strike: Source" ]||[ "${gamename}" == "Garry's Mod" ]; then
 		array_deps_required+=( lib32tinfo5 )
 	# Brainbread 2 and Don't Starve Together
@@ -204,7 +204,7 @@ elif [ -n "$(command -v yum)" ]; then
 	# 7 Days to Die
 	elif [ "${gamename}" ==  "7 Days To Die" ]; then
 		array_deps_required+=( telnet expect )
-	# No More Room in Hell
+	# No More Room in Hell, Counter Strike: Source and Garry's Mod
 	elif [ "${gamename}" == "No More Room in Hell" ]||[ "${gamename}" == "Counter Strike: Source" ]||[ "${gamename}" == "Garry's Mod" ]; then
 		array_deps_required+=( ncurses-libs.i686 )
 	# Brainbread 2 and Don't Starve Together
@@ -213,7 +213,7 @@ elif [ -n "$(command -v yum)" ]; then
 	# Project Zomboid
 	elif [ "${engine}" ==  "projectzomboid" ]; then
 		array_deps_required+=( java-1.7.0-openjdk )
-	# Unreal engine
+	# Unreal Engine
 	elif [ "${executable}" ==  "./ucc-bin" ]; then
 		#UT2K4
 		if [ -f "${executabledir}/ut2004-bin" ]; then


### PR DESCRIPTION
Fixes by adding more required dependencies to CS:S and GMod:
```
WARNING: Failed to load 32-bit libtinfo.so.5 or libncurses.so.5.
  Please install (lib32tinfo5 / ncurses-libs.i686 / equivalent) to enable readline.
```
This enables the access of previous commands with the arrow keys
Like in #212 

**There are maybe more (source) games with this warning.**