### PR TITLE
Fix the steam branch parameter

### DIFF
--- a/CounterStrikeGlobalOffensive/csgoserver
+++ b/CounterStrikeGlobalOffensive/csgoserver
@@ -78,6 +78,11 @@ githubbranch="master"
 # Steam
 appid="740"
 
+# Steam App Branch Select
+# Allows to opt into the various Steam app branches. Default branch is "".
+# Example: "-beta 1.35.4.4"
+branch=""
+
 # Server Details
 servicename="csgo-server"
 gamename="Counter Strike: Global Offensive"

--- a/GarrysMod/gmodserver
+++ b/GarrysMod/gmodserver
@@ -29,6 +29,11 @@ pushbullettoken="accesstoken"
 steamuser="anonymous"
 steampass=""
 
+# Steam App Branch Select
+# Allows to opt into the various Steam app branches. Default branch is "".
+# Example: "-beta prerelease "
+branch=""
+
 # Workshop Variables
 # http://wiki.garrysmod.com/page/Workshop_for_Dedicated_Servers
 workshopauth=""

--- a/NaturalSelection2/ns2server
+++ b/NaturalSelection2/ns2server
@@ -62,6 +62,11 @@ githubbranch="master"
 # Steam
 appid="4940"
 
+# Steam App Branch Select
+# Allows to opt into the various Steam app branches. Default branch is "".
+# Example: "-beta beta"
+branch=""
+
 # Server Details
 servicename="ns2-server"
 gamename="Natural Selection 2"

--- a/lgsm/functions/command_validate.sh
+++ b/lgsm/functions/command_validate.sh
@@ -24,9 +24,9 @@ fn_validation(){
 	fi
 
 	if [ "${engine}" == "goldsource" ]; then
-		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" +app_update "${appid}" validate +quit| tee -a "${scriptlog}"
+		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" ${branch} +app_update "${appid}" ${branch} validate +quit| tee -a "${scriptlog}"
 	else
-		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" validate +quit| tee -a "${scriptlog}"
+		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} validate +quit| tee -a "${scriptlog}"
 	fi
 	if [ $? != 0 ]; then
 		fn_print_fail_nl "Validating files: SteamCMD"

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -56,7 +56,7 @@ fn_install_server_files_steamcmd(){
 					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod "${appidmod}" +app_update "${appid}" ${branch} +quit
 					local exitcode=$?
 				else
-					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" +quit
+					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} +quit
 					local exitcode=$?
 				fi
 			elif [ "${counter}" -ge "5" ]; then
@@ -64,7 +64,7 @@ fn_install_server_files_steamcmd(){
 					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod "${appidmod}" +app_update "${appid}" ${branch} -validate +quit
 					local exitcode=$?
 				else
-					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" -validate +quit
+					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} -validate +quit
 					local exitcode=$?
 				fi
 			fi
@@ -82,7 +82,7 @@ fn_install_server_files_steamcmd(){
 		counter="0"
 		while [ "${counter}" -le "4" ]; do
 			counter=$((counter+1))
-			${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" -validate +quit
+			${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" ${branch} -validate +quit
 			local exitcode=$?
 		done
 	fi

--- a/lgsm/functions/update_steamcmd.sh
+++ b/lgsm/functions/update_steamcmd.sh
@@ -24,9 +24,9 @@ fn_update_steamcmd_dl(){
 	fi
 
 	if [ "${engine}" == "goldsource" ]; then
-		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" +quit | tee -a "${scriptlog}"
+		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" ${branch} +quit | tee -a "${scriptlog}"
 	else
-		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" +quit | tee -a "${scriptlog}"
+		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} +quit | tee -a "${scriptlog}"
 	fi
 
 	fix.sh


### PR DESCRIPTION
I noticed that there was already a parameter to opt into a steam app branch. However given parameter wasn't used in most methods. 

I fixed this and added the parameter to the game scripts of games which I sometimes host on non default branches.

Various developers use steam branches in various ways, so this feature might be not used by many server operators. However it's certainly nice to have.

I tested this change with the give game server apps (4940, 740 and 4020).