### PR TITLE
Added IPv6 bindings for TeamSpeak 3 server 3.0.13 and newer

### DIFF
--- a/TeamSpeak3/cfg/lgsm-default.ini
+++ b/TeamSpeak3/cfg/lgsm-default.ini
@@ -1,11 +1,11 @@
 machine_id=
 default_voice_port=9987
-voice_ip=0.0.0.0
+voice_ip=0.0.0.0, ::
 licensepath=
 filetransfer_port=30033
-filetransfer_ip=0.0.0.0
+filetransfer_ip=0.0.0.0, ::
 query_port=10011
-query_ip=0.0.0.0
+query_ip=0.0.0.0, ::
 query_ip_whitelist=query_ip_whitelist.txt
 query_ip_blacklist=query_ip_blacklist.txt
 dbplugin=ts3db_sqlite3


### PR DESCRIPTION
IPv6 support was added to TeamSpeak 3 server version 3.0.13. It's also possible to use IPv6 addresses in the query_ip_whitelist.txt, query_ip_blacklist.txt and tsdns_settings.ini. Please note, that you need to set the IPv6 inside square brackets in the tsdns_settings.ini (and only there) like this: ipv6-ts3.example.com=[2606:2800:220:1:248:1893:25c8:1946]:9987