### PR TITLE
Fix ARK params for ZSH

### DIFF
--- a/ARKSurvivalEvolved/arkserver
+++ b/ARKSurvivalEvolved/arkserver
@@ -39,7 +39,6 @@ maxplayers="50"
 ip="0.0.0.0"
 updateonstart="off"
 
-
 fn_parms(){
 parms="\"TheIsland?listen?MultiHome=${ip}?SessionName=${servername}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port}?ServerAdminPassword=${rconpassword}\""
 }

--- a/ARKSurvivalEvolved/arkserver
+++ b/ARKSurvivalEvolved/arkserver
@@ -39,8 +39,9 @@ maxplayers="50"
 ip="0.0.0.0"
 updateonstart="off"
 
+
 fn_parms(){
-parms="TheIsland?listen?MultiHome=${ip}?SessionName=${servername}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port}?ServerAdminPassword=${rconpassword}"
+parms="\"TheIsland?listen?MultiHome=${ip}?SessionName=${servername}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port}?ServerAdminPassword=${rconpassword}\""
 }
 
 #### Advanced Variables ####


### PR DESCRIPTION
In ZSH if you don't wrap the params from ARK in ```" ``` the tmux session won't start.
Tested and still working fine with bash.