### PR TITLE
Fix for Bug #2117

### DIFF
--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -138,7 +138,14 @@ fn_backup_compression(){
 		core_exit.sh
 	fi
 
-	tar -czf "${backupdir}/${backupname}.tar.gz" -C "${rootdir}" --exclude "${excludedir}" --exclude "${lockdir}/.backup.lock" ./.
+    # Check that rootdir is equal home dir
+    if [ ! ${rootdir} == ~ ]; then
+        if [ -d ~/.local/share/${gamedirname} ]; then
+            savegamedir="`realpath ~/.local/share/${gamedirname}`"
+        fi
+    fi
+
+    tar -czf "${backupdir}/${backupname}.tar.gz" -C "${rootdir}" "${savegamedir}" --exclude "${excludedir}" --exclude "${lockdir}/.backup.lock" ./.
 	local exitcode=$?
 	if [ ${exitcode} -ne 0 ]; then
 		fn_print_fail_eol


### PR DESCRIPTION
"#2117 [Backup] If server saves point to ${HOME} they may not be backed up"

This fix makes the backup include the savegames also on non standard installations.
Checked with sdtd.