### PR TITLE
fix(install): prevent steamcmd from being installed for non-steam gameservers

### DIFF
--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -223,9 +223,9 @@ fn_check_loop(){
 # Checks if dependency is installed or not.
 fn_deps_detector(){
 	## Check.
-	# SteamCMD: Will be removed from required array if non-free repo is not available.
+	# SteamCMD: Will be removed from required array if no appid is present or non-free repo is not available.
 	# This will cause SteamCMD to be installed using tar.
-	if [ "${deptocheck}" == "steamcmd" ]&&[ "${distroid}" == "debian" ]&& ! grep -qE "^deb .*non-free" /etc/apt/sources.list; then
+ if [ -z "${appid}" ]||[ "${deptocheck}" == "steamcmd" ]&&[ "${distroid}" == "debian" ]&& ! grep -qE "^deb .*non-free" /etc/apt/sources.list; then
 		array_deps_required=( "${array_deps_required[@]/steamcmd}" )
 		steamcmdstatus=1
 	# Java: Added for users using Oracle JRE to bypass check.
@@ -313,7 +313,7 @@ fi
 info_distro.sh
 
 if [ ! -f "${tmpdir}/dependency-no-check.tmp" ]&&[ ! -f "${datadir}/${distroid}-${distroversioncsv}.csv" ]; then
-	# Check that the disto dependency csv file exists.
+	# Check that the distro dependency csv file exists.
 	fn_check_file_github "lgsm/data" "${distroid}-${distroversioncsv}.csv"
 	if [ -n "${checkflag}" ]&&[ "${checkflag}" == "0" ]; then
 		fn_fetch_file_github "lgsm/data" "${distroid}-${distroversioncsv}.csv" "lgsm/data" "chmodx" "norun" "noforce" "nohash"


### PR DESCRIPTION
# Description

Any non-steam servers will no longer attempt to install steamcmd as a dependency requirement.

Fixes #3593

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [ ] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
