### PR TITLE
fix: Have message show the 'mailgunemail' variable instead of the 'email' …

### DIFF
--- a/lgsm/functions/alert_mailgun.sh
+++ b/lgsm/functions/alert_mailgun.sh
@@ -24,9 +24,9 @@ mailgunsend=$(curl --connect-timeout 10 -s --user "api:${mailguntoken}" \
 -F text="$(cat "${alertlog}")" "${mailgunapiurl}/v3/${mailgundomain}/messages")
 
 if [ -z "${mailgunsend}" ]; then
-	fn_print_fail_nl "Sending Email alert: Mailgun: ${email}"
-	fn_script_log_fatal "Sending Email alert: Mailgun: ${email}"
+	fn_print_fail_nl "Sending Email alert: Mailgun: ${mailgunemail}"
+	fn_script_log_fatal "Sending Email alert: Mailgun: ${mailgunemail}"
 else
-	fn_print_ok_nl "Sending Email alert: Mailgun: ${email}"
-	fn_script_log_pass "Sending Email alert: Mailgun: ${email}"
+	fn_print_ok_nl "Sending Email alert: Mailgun: ${mailgunemail}"
+	fn_script_log_pass "Sending Email alert: Mailgun: ${mailgunemail}"
 fi


### PR DESCRIPTION
# Description

`test-alert` command was showing incorrect email address when sending with mailgun.


Fixes #3617 

## Type of change

* [X] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [X] This pull request links to an issue.
* [ ] This pull request uses the `develop` branch as its base.
* [ ] This pull request Subject follows the Conventional Commits standard.
* [ ] This code follows the style guidelines of this project.
* [ ] I have performed a self-review of my code.
* [ ] I have checked that this code is commented where required.
* [ ] I have provided a detailed with enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
