### PR TITLE
fix(deps): prevent steamcmd showing as a required when it is not

### DIFF
--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -225,7 +225,7 @@ fn_deps_detector(){
 	## Check.
 	# SteamCMD: Will be removed from required array if no appid is present or non-free repo is not available.
 	# This will cause SteamCMD to be installed using tar.
-	if [ -z "${appid}" ]&&[ "${deptocheck}" == "steamcmd" ]||[ "${distroid}" == "debian" ]&& ! grep -qE "^deb .*non-free" /etc/apt/sources.list; then
+	if [ "${deptocheck}" == "steamcmd" ]&&[ -z "${appid}" ]||[ "${deptocheck}" == "steamcmd" ]&&[ "${distroid}" == "debian" ]&& ! grep -qE "^deb .*non-free" /etc/apt/sources.list; then
 		array_deps_required=( "${array_deps_required[@]/steamcmd}" )
 		steamcmdstatus=1
 	# Java: Added for users using Oracle JRE to bypass check.


### PR DESCRIPTION
# Description

prevent steamcmd showing as a required dependency when it is not required. Repeat issue.

Fixes #3593

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
