### PR TITLE
fix(papermc): update API URL to prevent update failures

### DIFF
--- a/lgsm/modules/update_pmc.sh
+++ b/lgsm/modules/update_pmc.sh
@@ -33,7 +33,7 @@ fn_update_localbuild() {
 
 fn_update_remotebuild() {
 	# Get remote build info.
-	apiurl="https://papermc.io/api/v2/projects"
+	apiurl="https://api.papermc.io/v2/projects"
 	# Get list of projects.
 	remotebuildresponse=$(curl -s "${apiurl}")
 	# Get list of Minecraft versions for project.


### PR DESCRIPTION
# Description

This change updates the API URL in `fn_update_remotebuild()` from [https://papermc.io/api/v2/projects](https://papermc.io/api/v2/projects) to [https://api.papermc.io/v2/projects](https://api.papermc.io/v2/projects), resolving an issue where PaperMC servers fail to start after updates due to the deprecated API endpoint.

Fixes #4727

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
