### PR TITLE
fix(mc): correct the of counting players online on Minecraft servers via gamedig

### DIFF
--- a/lgsm/modules/query_gamedig.sh
+++ b/lgsm/modules/query_gamedig.sh
@@ -42,9 +42,7 @@ if [ "$(command -v "${gamedigbinary}" 2> /dev/null)" ] && [ "$(command -v jq 2> 
 		fi
 
 		# numplayers.
-		if [ "${querytype}" == "minecraft" ]; then
-			gdplayers=$(echo "${gamedigraw}" | jq -re '.players | length-1')
-		elif [ "${querytype}" == "teamspeak3" ]; then
+		if [ "${querytype}" == "teamspeak3" ]; then
 			gdplayers=$(echo "${gamedigraw}" | jq -re '.raw.virtualserver_clientsonline')
 		else
 			gdplayers=$(echo "${gamedigraw}" | jq -re '.players | length')


### PR DESCRIPTION
# Description

The current iteration of this command always produces a value of 0 when running it on Minecraft servers. Not sure if there was an issue with Gamedig on a previous version but that matter seems to be resolved with the version I am using which is 5.1.4. This request simply removes the 'if' statement related to Minecraft servers so it can use the same command as all the other servers.

Fixes #4724

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
