### PR TITLE
Fix(deps): Remove libtinfo5:i386 dependecy for Debian 13

### DIFF
--- a/lgsm/data/debian-13.csv
+++ b/lgsm/data/debian-13.csv
@@ -11,7 +11,7 @@ av
 bb
 bb2,libcurl4-gnutls-dev:i386
 bd
-bf1942,libncurses5:i386,libtinfo5:i386
+bf1942,libncurses5:i386
 bfv,libncurses5:i386,libstdc++5:i386
 bmdm,libncurses5:i386
 bo
@@ -31,7 +31,7 @@ cs
 cs2
 cscz
 csgo
-css,libtinfo5:i386
+css
 ct
 dab
 dayz
@@ -48,7 +48,7 @@ etl
 ets2
 fctr
 fof
-gmod,libtinfo5:i386
+gmod
 hcu
 hl2dm
 hldm
@@ -72,7 +72,7 @@ mohaa,libstdc++5:i386
 mta,libncursesw5,libxml2-utils
 nd
 nec
-nmrih,libtinfo5:i386
+nmrih
 ns
 ns2,speex,libtbb12
 ns2c,speex:i386,libtbb12
@@ -104,7 +104,7 @@ scpsl,mono-complete
 scpslsm,mono-complete
 sdtd,telnet,expect,libxml2-utils
 sf
-sfc,libtinfo5:i386
+sfc
 sm,telnet,expect
 sof2
 sol
@@ -135,5 +135,5 @@ wf
 wmc,openjdk21-jre
 wurm,xvfb
 xnt
-zmr,libtinfo5:i386
-zps,libtinfo5:i386
+zmr
+zps


### PR DESCRIPTION
# Description

This PR removes the `libtinfo5:i386` dependency for Debian 13. This Dependency is no longer available there, which causes LinuxGSM to constantly try to install it and fail. As it's not working anyway things shouldn't get worse.

I've tested this by using linuxgsm against my branch on a Debian 13 VM, it seems to be working fine.

Fixes #4827

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**