### PR TITLE
Fix(deps): Fix openjdk-jre dependecy for Debian 13

### DIFF
--- a/lgsm/data/debian-13.csv
+++ b/lgsm/data/debian-13.csv
@@ -65,7 +65,7 @@ kf
 kf2
 l4d
 l4d2
-mc,openjdk-22-jre
+mc,openjdk-25-jre
 mcb
 mh
 mohaa,libstdc++5:i386
@@ -81,12 +81,12 @@ onset,libmariadb-dev
 opfor
 pc
 pc2
-pmc,openjdk-22-jre
+pmc,openjdk-25-jre
 squad44
 pvkii
 pvr,libc++1
 pw
-pz,openjdk-22-jre,rng-tools5
+pz,openjdk-25-jre,rng-tools5
 q2
 q3
 q4
@@ -96,7 +96,7 @@ ricochet
 ro
 rtcw
 rust,lib32z1
-rw,openjdk-22-jre
+rw,openjdk-25-jre
 samp
 sb
 sbots


### PR DESCRIPTION
# Description

This PR changes the `openjdk-22-jre` dependency to `openjdk-25-jre` for Debian 13. This dependency is not available in Debian 13 which causes LinuxGSM to constantly try to install it and fail.

I've tested this by using linuxgsm against my branch on a Debian 13 VM, it seems to be working fine.

Fixes #4829

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
