### PR TITLE
fix(cs2server): use cs2.sh script instead of cs2 binary for server startup

### DIFF
--- a/lgsm/config-default/config-lgsm/cs2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cs2server/_default.cfg
@@ -163,8 +163,8 @@ glibc="2.31"
 
 ## Game Server Directories
 systemdir="${serverfiles}/game/csgo"
-executabledir="${serverfiles}/game/bin/linuxsteamrt64"
-executable="./cs2"
+executabledir="${serverfiles}/game"
+executable="./cs2.sh"
 servercfgdir="${systemdir}/cfg"
 servercfg="${selfname}.cfg"
 servercfgdefault="server.cfg"


### PR DESCRIPTION
Update CS2 server launch to use the `cs2.sh` script as recommended by Valve. The script properly sets `LD_LIBRARY_PATH` environment variable, which is required after recent CS2 updates.

Fixes #4842, #4833, #4824

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
