### PR TITLE
Fix(scpslserver/deps): Add libicu76 as dependecy for SCP: Secret Laboratory on Debian 13

### DIFF
--- a/lgsm/data/debian-13.csv
+++ b/lgsm/data/debian-13.csv
@@ -100,7 +100,7 @@ rw,openjdk-25-jre
 samp
 sb
 sbots
-scpsl,mono-complete
+scpsl,mono-complete,libicu76
 scpslsm,mono-complete
 sdtd,telnet,expect,libxml2-utils
 sf


### PR DESCRIPTION
# Description

On Debian 13 starting SCP: Secret Laboratory fails with the following output:

```

Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu (or icu-libs) using your package manager and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.
```

After installing the `libicu76` package manually, the server starts up just fine.

Fixes #4868

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
