### PR TITLE
feat(etl): add ET: Legacy downloader and update module

### DIFF
--- a/lgsm/config-default/config-lgsm/etlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/etlserver/_default.cfg
@@ -141,7 +141,7 @@ consoleinteract="yes"
 # Do not edit
 gamename="ET: Legacy"
 engine="idtech3"
-glibc="2.7"
+glibc="2.17"
 
 #### Directories ####
 # Edit with care

--- a/lgsm/config-default/config-lgsm/etlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/etlserver/_default.cfg
@@ -160,7 +160,7 @@ backupdir="${lgsmdir}/backup"
 
 ## Logging Directories
 [ -n "${LGSM_LOGDIR}" ] && logdir="${LGSM_LOGDIR}" || logdir="${rootdir}/log"
-gamelogdir="${serverfiles}/Logs"
+gamelogdir="${serverfiles}/legacy"
 lgsmlogdir="${logdir}/script"
 consolelogdir="${logdir}/console"
 lgsmlog="${lgsmlogdir}/${selfname}-script.log"

--- a/lgsm/modules/command_check_update.sh
+++ b/lgsm/modules/command_check_update.sh
@@ -34,6 +34,8 @@ elif [ "${shortname}" == "ut99" ]; then
 	update_ut99.sh
 elif [ "${shortname}" == "xnt" ]; then
 	update_xnt.sh
+elif [ "${shortname}" == "etl" ]; then
+	update_etl.sh
 else
 	update_steamcmd.sh
 fi

--- a/lgsm/modules/command_update.sh
+++ b/lgsm/modules/command_update.sh
@@ -35,6 +35,8 @@ elif [ "${shortname}" == "ut99" ]; then
 	update_ut99.sh
 elif [ "${shortname}" == "xnt" ]; then
 	update_xnt.sh
+elif [ "${shortname}" == "etl" ]; then
+	update_etl.sh
 else
 	update_steamcmd.sh
 fi

--- a/lgsm/modules/core_dl.sh
+++ b/lgsm/modules/core_dl.sh
@@ -267,9 +267,9 @@ fn_dl_extract() {
 		fi
 	elif [ "${mime}" == "application/zip" ]; then
 		if [ -n "${extractsrc}" ]; then
-			temp_extractdir="${tmpdir}/Xonotic"
+			temp_extractdir="${tmpdir}/${extractsrc}"
 			extractcmd=$(unzip -qo "${local_filedir}/${local_filename}" "${extractsrc}/*" -d "${temp_extractdir}")
-			find "${temp_extractdir}/${extractsrc}" -mindepth 1 -maxdepth 1 -exec mv -t "${extractdest}" {} +
+			cp -a "${temp_extractdir}/${extractsrc}/." "${extractdest}/"
 			rm -rf "${temp_extractdir}"
 		else
 			extractcmd=$(unzip -qo -d "${extractdest}" "${local_filedir}/${local_filename}")

--- a/lgsm/modules/core_dl.sh
+++ b/lgsm/modules/core_dl.sh
@@ -204,7 +204,7 @@ fn_dl_hash() {
 			fn_print_error_nl "hash length not known for hash type"
 			core_exit.sh
 		fi
-		echo -en "verifying ${local_filename} with ${hashtype}..."
+		echo -en "verifying ${local_filename} with ${hashtype}"
 		fn_sleep_time
 		hashsumcmd=$(${hashbin} "${local_filedir}/${local_filename}" | awk '{print $1}')
 		if [ "${hashsumcmd}" != "${hash}" ]; then

--- a/lgsm/modules/core_getopt.sh
+++ b/lgsm/modules/core_getopt.sh
@@ -66,7 +66,7 @@ currentopt=("${cmd_start[@]}" "${cmd_stop[@]}" "${cmd_restart[@]}" "${cmd_monito
 currentopt+=("${cmd_update_linuxgsm[@]}")
 
 # Exclude noupdate games here.
-if [ "${shortname}" == "jk2" ] || [ "${engine}" != "idtech3" ]; then
+if [ "${shortname}" == "jk2" ] || [ "${shortname}" == "etl" ] || [ "${engine}" != "idtech3" ]; then
 	if [ "${shortname}" != "bf1942" ] && [ "${shortname}" != "bfv" ] && [ "${engine}" != "idtech2" ] && [ "${engine}" != "iw2.0" ] && [ "${engine}" != "iw3.0" ] && [ "${engine}" != "quake" ] && [ "${shortname}" != "samp" ] && [ "${shortname}" != "ut2k4" ]; then
 		currentopt+=("${cmd_update[@]}" "${cmd_check_update[@]}")
 		# force update for SteamCMD or Multi Theft Auto only.

--- a/lgsm/modules/core_modules.sh
+++ b/lgsm/modules/core_modules.sh
@@ -660,6 +660,11 @@ fn_update_modules.sh() {
 	fn_fetch_module
 }
 
+update_etl.sh() {
+	modulefile="${FUNCNAME[0]}"
+	fn_fetch_module
+}
+
 update_fctr.sh() {
 	modulefile="${FUNCNAME[0]}"
 	fn_fetch_module

--- a/lgsm/modules/install_server_files.sh
+++ b/lgsm/modules/install_server_files.sh
@@ -80,14 +80,6 @@ fn_install_server_files() {
 		run="norun"
 		force="noforce"
 		md5="2c6be1bb66ea631b9b2e7ae6216c6680"
-	elif [ "${shortname}" == "etl" ]; then
-		remote_fileurl="http://linuxgsm.download/WolfensteinEnemyTerritory/etlegacy-v2.78.1-i386-et-260b.tar.xz"
-		local_filedir="${tmpdir}"
-		local_filename="etlegacy-v2.78.1-i386-et-260b.tar.xz"
-		chmodx="nochmodx"
-		run="norun"
-		force="noforce"
-		md5="7c08b52cb09b30eadb98ea05ef780fc7"
 	elif [ "${shortname}" == "mohaa" ]; then
 		remote_fileurl="http://linuxgsm.download/MedalofHonorAlliedAssault/moh_revival_v1.12_RC3.5.1.tar.xz"
 		local_filedir="${tmpdir}"
@@ -280,6 +272,8 @@ elif [ "${shortname}" == "ut99" ]; then
 	update_ut99.sh
 elif [ "${shortname}" == "xnt" ]; then
 	update_xnt.sh
+elif [ "${shortname}" == "etl" ]; then
+	update_etl.sh
 elif [ -z "${appid}" ] || [ "${shortname}" == "ahl" ] || [ "${shortname}" == "bb" ] || [ "${shortname}" == "q4" ] || [ "${shortname}" == "ns" ] || [ "${shortname}" == "sfc" ] || [ "${shortname}" == "ts" ] || [ "${shortname}" == "vs" ] || [ "${shortname}" == "zmr" ]; then
 	if [ "${shortname}" == "ut" ]; then
 		install_eula.sh

--- a/lgsm/modules/update_etl.sh
+++ b/lgsm/modules/update_etl.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# LinuxGSM update_etl.sh module
+# Author: Daniel Gibbs
+# Contributors: https://linuxgsm.com/contrib
+# Website: https://linuxgsm.com
+# Description: Handles updating of ET: Legacy servers.
+
+moduleselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+fn_update_dl() {
+	# Download and extract files to serverfiles.
+	fn_fetch_file "${remotebuildurl}" "" "" "" "${tmpdir}" "${remotebuildfilename}" "nochmodx" "norun" "force" "${remotebuildhash}"
+	fn_dl_extract "${tmpdir}" "${remotebuildfilename}" "${serverfiles}"
+	echo "${remotebuild}" > "${serverfiles}/build.txt"
+	fn_clear_tmp
+}
+
+fn_update_localbuild() {
+	# Gets local build info.
+	fn_print_dots "Checking local build: ${remotelocation}"
+	# Uses build file to get local build.
+	localbuild=$(head -n 1 "${serverfiles}/build.txt" 2> /dev/null)
+	if [ -z "${localbuild}" ]; then
+		fn_print_error "Checking local build: ${remotelocation}: missing local build info"
+		fn_script_log_error "Missing local build info"
+		fn_script_log_error "Set localbuild to 0"
+		localbuild="0"
+	else
+		fn_print_ok "Checking local build: ${remotelocation}"
+		fn_script_log_pass "Checking local build"
+	fi
+}
+
+fn_update_remotebuild() {
+	# Gets remote build info.
+	apiurl="https://api.github.com/repos/GameServerManagers/etlserver-build/releases/latest"
+	remotebuildresponse=$(curl -s "${apiurl}")
+	remotebuildfilename=$(echo "${remotebuildresponse}" | jq -r '.assets[] | select(.browser_download_url | contains("i386-et-260b")) | .name')
+	remotebuildurl=$(echo "${remotebuildresponse}" | jq -r '.assets[] | select(.browser_download_url | contains("i386-et-260b")) | .browser_download_url')
+	remotebuild=$(echo "${remotebuildresponse}" | jq -r '.tag_name')
+	remotebuildhash=$(echo "${remotebuildresponse}" | jq -r '.body' | grep 'MD5' | awk '{print $NF}')
+
+	if [ "${firstcommandname}" != "INSTALL" ]; then
+		fn_print_dots "Checking remote build: ${remotelocation}"
+		# Checks if remotebuild variable has been set.
+		if [ -z "${remotebuild}" ] || [ "${remotebuild}" == "null" ]; then
+			fn_print_fail "Checking remote build: ${remotelocation}"
+			fn_script_log_fail "Checking remote build"
+			core_exit.sh
+		else
+			fn_print_ok "Checking remote build: ${remotelocation}"
+			fn_script_log_pass "Checking remote build"
+		fi
+	else
+		# Checks if remotebuild variable has been set.
+		if [ -z "${remotebuild}" ] || [ "${remotebuild}" == "null" ]; then
+			fn_print_failure "Unable to get remote build"
+			fn_script_log_fail "Unable to get remote build"
+			core_exit.sh
+		fi
+	fi
+}
+
+fn_update_compare() {
+	fn_print_dots "Checking for update: ${remotelocation}"
+	# Update has been found or force update.
+	if [ "${localbuild}" != "${remotebuild}" ] || [ "${forceupdate}" == "1" ]; then
+		# Create update lockfile.
+		date '+%s' > "${lockdir:?}/update.lock"
+		fn_print_ok_nl "Checking for update: ${remotelocation}"
+		fn_print "\n"
+		fn_print_nl "${bold}${underline}Update${default} available"
+		fn_print_nl "* Local build: ${red}${localbuild}${default}"
+		fn_print_nl "* Remote build: ${green}${remotebuild}${default}"
+		if [ -n "${branch}" ]; then
+			fn_print_nl "* Branch: ${branch}"
+		fi
+		if [ -f "${rootdir}/.dev-debug" ]; then
+			fn_print_nl "Remote build info"
+			fn_print_nl "* apiurl: ${apiurl}"
+			fn_print_nl "* remotebuildfilename: ${remotebuildfilename}"
+			fn_print_nl "* remotebuildurl: ${remotebuildurl}"
+			fn_print_nl "* remotebuild: ${remotebuild}"
+		fi
+		fn_print "\n"
+		fn_script_log_info "Update available"
+		fn_script_log_info "Local build: ${localbuild}"
+		fn_script_log_info "Remote build: ${remotebuild}"
+		if [ -n "${branch}" ]; then
+			fn_script_log_info "Branch: ${branch}"
+		fi
+		fn_script_log_info "${localbuild} > ${remotebuild}"
+
+		if [ "${commandname}" == "UPDATE" ]; then
+			date +%s > "${lockdir:?}/last-updated.lock"
+			unset updateonstart
+			check_status.sh
+			# If server stopped.
+			if [ "${status}" == "0" ]; then
+				fn_update_dl
+				if [ "${localbuild}" == "0" ]; then
+					exitbypass=1
+					command_start.sh
+					fn_firstcommand_reset
+					exitbypass=1
+					fn_sleep_time_5
+					command_stop.sh
+					fn_firstcommand_reset
+				fi
+			# If server started.
+			else
+				fn_print_restart_warning
+				exitbypass=1
+				command_stop.sh
+				fn_firstcommand_reset
+				exitbypass=1
+				fn_update_dl
+				exitbypass=1
+				command_start.sh
+				fn_firstcommand_reset
+			fi
+			unset exitbypass
+			alert="update"
+		elif [ "${commandname}" == "CHECK-UPDATE" ]; then
+			alert="check-update"
+		fi
+		alert.sh
+	else
+		fn_print_ok_nl "Checking for update: ${remotelocation}"
+		fn_print "\n"
+		fn_print_nl "${bold}${underline}No update${default} available"
+		fn_print_nl "* Local build: ${green}${localbuild}${default}"
+		fn_print_nl "* Remote build: ${green}${remotebuild}${default}"
+		if [ -n "${branch}" ]; then
+			fn_print_nl "* Branch: ${branch}"
+		fi
+		fn_print "\n"
+		fn_script_log_info "No update available"
+		fn_script_log_info "Local build: ${localbuild}"
+		fn_script_log_info "Remote build: ${remotebuild}"
+		if [ -n "${branch}" ]; then
+			fn_script_log_info "Branch: ${branch}"
+		fi
+		if [ -f "${rootdir}/.dev-debug" ]; then
+			fn_print_nl "Remote build info"
+			fn_print_nl "* apiurl: ${apiurl}"
+			fn_print_nl "* remotebuildfilename: ${remotebuildfilename}"
+			fn_print_nl "* remotebuildurl: ${remotebuildurl}"
+			fn_print_nl "* remotebuild: ${remotebuild}"
+		fi
+	fi
+}
+
+# The location where the builds are checked and downloaded.
+remotelocation="github.com"
+
+if [ "${firstcommandname}" == "INSTALL" ]; then
+	fn_update_remotebuild
+	fn_update_dl
+else
+	fn_print_dots "Checking for update"
+	fn_print_dots "Checking for update: ${remotelocation}"
+	fn_script_log_info "Checking for update: ${remotelocation}"
+	fn_update_localbuild
+	fn_update_remotebuild
+	fn_update_compare
+fi

--- a/lgsm/modules/update_etl.sh
+++ b/lgsm/modules/update_etl.sh
@@ -18,8 +18,14 @@ fn_update_dl() {
 fn_update_localbuild() {
 	# Gets local build info.
 	fn_print_dots "Checking local build: ${remotelocation}"
-	# Uses build file to get local build.
-	localbuild=$(head -n 1 "${serverfiles}/build.txt" 2> /dev/null)
+	# Try to get build version from etconsole.log.
+	if [ -f "${serverfiles}/legacy/etconsole.log" ]; then
+		localbuild=$(grep "Initializing legacy game" "${serverfiles}/legacy/etconsole.log" | sed -n 's/.*\^2\(v[0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' | tail -1)
+	fi
+	# Fall back to build.txt if log parse failed or log does not exist.
+	if [ -z "${localbuild}" ]; then
+		localbuild=$(head -n 1 "${serverfiles}/build.txt" 2> /dev/null)
+	fi
 	if [ -z "${localbuild}" ]; then
 		fn_print_error "Checking local build: ${remotelocation}: missing local build info"
 		fn_script_log_error "Missing local build info"

--- a/lgsm/modules/update_etl.sh
+++ b/lgsm/modules/update_etl.sh
@@ -44,7 +44,7 @@ fn_update_remotebuild() {
 	remotebuildfilename=$(echo "${remotebuildresponse}" | jq -r '.assets[] | select(.browser_download_url | contains("i386-et-260b")) | .name')
 	remotebuildurl=$(echo "${remotebuildresponse}" | jq -r '.assets[] | select(.browser_download_url | contains("i386-et-260b")) | .browser_download_url')
 	remotebuild=$(echo "${remotebuildresponse}" | jq -r '.tag_name')
-	remotebuildhash=$(echo "${remotebuildresponse}" | jq -r '.body' | grep 'MD5' | awk '{print $NF}')
+	remotebuildhash=$(echo "${remotebuildresponse}" | jq -r '.body' | grep 'MD5' | grep -oE '[a-f0-9]{32}')
 
 	if [ "${firstcommandname}" != "INSTALL" ]; then
 		fn_print_dots "Checking remote build: ${remotelocation}"

--- a/lgsm/modules/update_etl.sh
+++ b/lgsm/modules/update_etl.sh
@@ -19,8 +19,8 @@ fn_update_localbuild() {
 	# Gets local build info.
 	fn_print_dots "Checking local build: ${remotelocation}"
 	# Try to get build version from etconsole.log.
-	if [ -f "${serverfiles}/legacy/etconsole.log" ]; then
-		localbuild=$(grep "Initializing legacy game" "${serverfiles}/legacy/etconsole.log" | sed -n 's/.*\^2\(v[0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' | tail -1)
+	if [ -f "${gamelogdir}/etconsole.log" ]; then
+		localbuild=$(grep "Initializing legacy game" "${gamelogdir}/etconsole.log" | sed -n 's/.*\^2\(v[0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' | tail -1)
 	fi
 	# Fall back to build.txt if log parse failed or log does not exist.
 	if [ -z "${localbuild}" ]; then

--- a/lgsm/modules/update_xnt.sh
+++ b/lgsm/modules/update_xnt.sh
@@ -55,6 +55,7 @@ fn_update_remotebuild() {
 	remotebuildfilename="${remotebuildfilename}.zip"
 	remotebuildurl="https://dl.xonotic.org/${remotebuildfilename}"
 	remotebuild="${remotebuildtag}"
+	remotebuildhash=$(curl -s "https://dl.xonotic.org/${remotebuildtag}.sha512" | grep "${remotebuildfilename}$" | grep -oE '[a-f0-9]{128}')
 
 	if [ "${firstcommandname}" != "INSTALL" ]; then
 		fn_print_dots "Checking remote build: ${remotelocation}"

--- a/lgsm/modules/update_xnt.sh
+++ b/lgsm/modules/update_xnt.sh
@@ -55,7 +55,7 @@ fn_update_remotebuild() {
 	remotebuildfilename="${remotebuildfilename}.zip"
 	remotebuildurl="https://dl.xonotic.org/${remotebuildfilename}"
 	remotebuild="${remotebuildtag}"
-	remotebuildhash=$(curl -s "https://dl.xonotic.org/${remotebuildtag}.sha512" | grep "${remotebuildfilename}$" | grep -oE '[a-f0-9]{128}')
+	remotebuildhash=$(curl -s "https://dl.xonotic.org/${remotebuildfilename%.zip}.sha512" | grep "${remotebuildfilename}$" | grep -oE '[a-f0-9]{128}')
 
 	if [ "${firstcommandname}" != "INSTALL" ]; then
 		fn_print_dots "Checking remote build: ${remotelocation}"


### PR DESCRIPTION
# Description

Adds a native downloader and update module for ET: Legacy (`etlserver`), replacing the old static file install with a dynamic GitHub Releases-based updater. Also fixes several bugs found during development and a pre-existing bug in the Xonotic hash verification.

**New: `update_etl.sh`**
- Fetches the latest ET: Legacy release from the `GameServerManagers/etlserver-build` GitHub Releases API
- Selects the i386+ET 2.60b compatible build asset automatically
- Verifies the downloaded archive against the MD5 hash from the release notes
- Supports install, update, and check-update commands

**New: ETL update wired into core**
- Added `update_etl.sh` to `core_modules.sh`
- Added `etl` branch to `command_update.sh`, `command_check_update.sh`, and `install_server_files.sh`
- Added `etl` to `core_getopt.sh` update exclusion list (uses own updater, not SteamCMD)
- Removed the old hardcoded static install from `install_server_files.sh`

**`etlserver/_default.cfg` fixes:**
- Fixed `gamelogdir`: was `${serverfiles}/Logs` (copy-pasted from bf1942), corrected to `${serverfiles}/legacy`
- Fixed `glibc`: was `"2.7"`, corrected to `"2.17"` (confirmed via `./etlserver dg`)

**`update_etl.sh` fixes:**
- Fixed `fn_update_localbuild`: now reads `${gamelogdir}/etconsole.log` first (greps for `Initializing legacy game ^2vX.Y.Z`), falls back to `build.txt`, then `"0"`
- Fixed MD5 hash extraction: replaced `awk '{print $NF}'` with `grep -oE '[a-f0-9]{32}'` for format-agnostic extraction

**`update_xnt.sh` fix:**
- Fixed `remotebuildhash`: was derived from `${remotebuildtag}` (e.g. `xonotic-v0.8.6.sha512`) which 404s; corrected to use `${remotebuildfilename}` (e.g. `xonotic-0.8.6.sha512`)

**`core_dl.sh` fixes:**
- Fixed zip extraction with `extractsrc`: replaced `find+mv` with `cp -a` to handle cross-device moves and updates to non-empty directories
- Fixed duplicate `...` in hash verification output line

Fixes #4532

## Type of change

- [x] Bug fix (a change which fixes an issue).
- [x] New feature (a change which adds functionality).
- [ ] New Server (new server added).
- [ ] Refactor (restructures existing code).
- [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

- [x] This pull request links to an issue.
- [x] This pull request uses the `develop` branch as its base.
- [x] This pull request subject follows the Conventional Commits standard.
- [x] This code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have checked that this code is commented where required.
- [x] I have provided a detailed enough description of this PR.
- [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

- User docs: <https://github.com/GameServerManagers/LinuxGSM-Docs>
- Dev docs: <https://github.com/GameServerManagers/LinuxGSM-Dev-Docs>

**Thank you for your Pull Request!**