### PR TITLE
fix(install_config): replace cp -nv with explicit file existence check

### DIFF
--- a/lgsm/modules/install_config.sh
+++ b/lgsm/modules/install_config.sh
@@ -34,7 +34,7 @@ fn_default_config_remote() {
 		if [ "${config}" == "${servercfgdefault}" ]; then
 			mkdir -p "${servercfgdir}"
 			echo -en "copying config file [ ${italic}${servercfgfullpath}${default} ]"
-			if [ ! -f "${servercfgfullpath}" ]; then
+			if [ ! -e "${servercfgfullpath}" ] && [ ! -L "${servercfgfullpath}" ]; then
 				cp "${lgsmdir}/config-default/config-game/${config}" "${servercfgfullpath}"
 				exitcode=$?
 				[ "${exitcode}" -eq 0 ] && changes="copied"
@@ -53,7 +53,7 @@ fn_default_config_remote() {
 		elif [ "${shortname}" == "arma3" ] && [ "${config}" == "${networkcfgdefault}" ]; then
 			mkdir -p "${servercfgdir}"
 			echo -en "copying config file [ ${italic}${networkcfgfullpath}${default} ]"
-			if [ ! -f "${networkcfgfullpath}" ]; then
+			if [ ! -e "${networkcfgfullpath}" ] && [ ! -L "${networkcfgfullpath}" ]; then
 				cp "${lgsmdir}/config-default/config-game/${config}" "${networkcfgfullpath}"
 				exitcode=$?
 				[ "${exitcode}" -eq 0 ] && changes="copied"
@@ -71,7 +71,7 @@ fn_default_config_remote() {
 			fi
 		elif [ "${shortname}" == "dst" ] && [ "${config}" == "${clustercfgdefault}" ]; then
 			echo -en "copying config file [ ${italic}${clustercfgfullpath}${default} ]"
-			if [ ! -f "${clustercfgfullpath}" ]; then
+			if [ ! -e "${clustercfgfullpath}" ] && [ ! -L "${clustercfgfullpath}" ]; then
 				cp "${lgsmdir}/config-default/config-game/${clustercfgdefault}" "${clustercfgfullpath}"
 				exitcode=$?
 				[ "${exitcode}" -eq 0 ] && changes="copied"
@@ -89,7 +89,7 @@ fn_default_config_remote() {
 			fi
 		else
 			echo -en "copying config file [ ${italic}${servercfgdir}/${config}${default} ]"
-			if [ ! -f "${servercfgdir}/${config}" ]; then
+			if [ ! -e "${servercfgdir}/${config}" ] && [ ! -L "${servercfgdir}/${config}" ]; then
 				cp "${lgsmdir}/config-default/config-game/${config}" "${servercfgdir}/${config}"
 				exitcode=$?
 				[ "${exitcode}" -eq 0 ] && changes="copied"

--- a/lgsm/modules/install_config.sh
+++ b/lgsm/modules/install_config.sh
@@ -34,8 +34,13 @@ fn_default_config_remote() {
 		if [ "${config}" == "${servercfgdefault}" ]; then
 			mkdir -p "${servercfgdir}"
 			echo -en "copying config file [ ${italic}${servercfgfullpath}${default} ]"
-			changes+=$(cp -nv "${lgsmdir}/config-default/config-game/${config}" "${servercfgfullpath}")
-			exitcode=$?
+			if [ ! -f "${servercfgfullpath}" ]; then
+				cp "${lgsmdir}/config-default/config-game/${config}" "${servercfgfullpath}"
+				exitcode=$?
+				[ "${exitcode}" -eq 0 ] && changes="copied"
+			else
+				exitcode=0
+			fi
 			if [ "${exitcode}" -ne 0 ]; then
 				fn_print_fail_eol_nl
 				fn_script_log_fail "copying config file ${servercfgfullpath}"
@@ -48,7 +53,13 @@ fn_default_config_remote() {
 		elif [ "${shortname}" == "arma3" ] && [ "${config}" == "${networkcfgdefault}" ]; then
 			mkdir -p "${servercfgdir}"
 			echo -en "copying config file [ ${italic}${networkcfgfullpath}${default} ]"
-			changes+=$(cp -nv "${lgsmdir}/config-default/config-game/${config}" "${networkcfgfullpath}")
+			if [ ! -f "${networkcfgfullpath}" ]; then
+				cp "${lgsmdir}/config-default/config-game/${config}" "${networkcfgfullpath}"
+				exitcode=$?
+				[ "${exitcode}" -eq 0 ] && changes="copied"
+			else
+				exitcode=0
+			fi
 			if [ "${exitcode}" -ne 0 ]; then
 				fn_print_fail_eol_nl
 				fn_script_log_fail "copying config file ${networkcfgdefault}"
@@ -60,7 +71,13 @@ fn_default_config_remote() {
 			fi
 		elif [ "${shortname}" == "dst" ] && [ "${config}" == "${clustercfgdefault}" ]; then
 			echo -en "copying config file [ ${italic}${clustercfgfullpath}${default} ]"
-			changes+=$(cp -nv "${lgsmdir}/config-default/config-game/${clustercfgdefault}" "${clustercfgfullpath}")
+			if [ ! -f "${clustercfgfullpath}" ]; then
+				cp "${lgsmdir}/config-default/config-game/${clustercfgdefault}" "${clustercfgfullpath}"
+				exitcode=$?
+				[ "${exitcode}" -eq 0 ] && changes="copied"
+			else
+				exitcode=0
+			fi
 			if [ "${exitcode}" -ne 0 ]; then
 				fn_print_fail_eol_nl
 				fn_script_log_fail "copying config file ${clustercfgfullpath}"
@@ -72,7 +89,13 @@ fn_default_config_remote() {
 			fi
 		else
 			echo -en "copying config file [ ${italic}${servercfgdir}/${config}${default} ]"
-			changes+=$(cp -nv "${lgsmdir}/config-default/config-game/${config}" "${servercfgdir}/${config}")
+			if [ ! -f "${servercfgdir}/${config}" ]; then
+				cp "${lgsmdir}/config-default/config-game/${config}" "${servercfgdir}/${config}"
+				exitcode=$?
+				[ "${exitcode}" -eq 0 ] && changes="copied"
+			else
+				exitcode=0
+			fi
 			if [ "${exitcode}" -ne 0 ]; then
 				fn_print_fail_eol_nl
 				fn_script_log_fail "copying config file ${servercfgdir}/${config}"


### PR DESCRIPTION
# Description

Newer versions of coreutils (Ubuntu 24.04+, Debian 13+, Rocky Linux 9+) changed the behaviour of `cp -n`, either emitting a portability warning or rejecting the `--update` argument entirely, breaking the config file copy step during install.

- Replace all `cp -nv` calls in `install_config.sh` with an explicit `[ ! -f dest ]` existence check before copying
- Preserves the same OK/SKIP/FAIL output behaviour
- Portable across all supported distros

Fixes #4700

## Type of change

- [x] Bug fix (a change which fixes an issue).
- [ ] New feature (a change which adds functionality).
- [ ] New Server (new server added).
- [ ] Refactor (restructures existing code).
- [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

- [x] This pull request links to an issue.
- [x] This pull request uses the `develop` branch as its base.
- [x] This pull request subject follows the Conventional Commits standard.
- [x] This code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have checked that this code is commented where required.
- [x] I have provided a detailed enough description of this PR.
- [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

- User docs: <https://github.com/GameServerManagers/LinuxGSM-Docs>
- Dev docs: <https://github.com/GameServerManagers/LinuxGSM-Dev-Docs>

**Thank you for your Pull Request!**