### PR TITLE
papermc: add OpenJDK-25 (headless) dependency

### DIFF
--- a/lgsm/data/ubuntu-24.04.csv
+++ b/lgsm/data/ubuntu-24.04.csv
@@ -82,7 +82,7 @@ onset,libmariadb-dev
 opfor
 pc
 pc2
-pmc,openjdk-21-jre
+pmc,openjdk-25-jre-headless
 pvkii
 pvr,libc++1
 pw


### PR DESCRIPTION
For a bit of pedantry, use headless. It will save just a little bit of space =)

# Description

Dev builds of papermc will not work on older jre, albeit it's still in alpha/beta, some time in the future it will be the stable build. I have not noticed any issues running the stable build with jre-25.

https://github.com/GameServerManagers/LinuxGSM/issues/4889 (albeit not specific to PaperMC, should I make one?)
https://github.com/GameServerManagers/docker-gameserver/issues/153 (but wrong repo)

## Type of change

- [X] Bug fix (a change which fixes an issue).

## Checklist

PR will not be merged until all steps are complete.

- [X] This pull request links to an issue.
- [X] This pull request uses the `develop` branch as its base.
- [X] This pull request subject follows the Conventional Commits standard.
- [X] This code follows the style guidelines of this project.
- [X] I have performed a self-review of my code.
- [X] I have checked that this code is commented where required.
- [X] I have provided a detailed enough description of this PR.
- [X] I have checked if documentation needs updating.