### PR TITLE
feat(bb): add BrainBread server update functionality

### DIFF
--- a/lgsm/data/serverlist.csv
+++ b/lgsm/data/serverlist.csv
@@ -67,6 +67,7 @@ l4d,l4dserver,Left 4 Dead,ubuntu-24.04
 l4d2,l4d2server,Left 4 Dead 2,ubuntu-24.04
 mc,mcserver,Minecraft,ubuntu-24.04
 mcb,mcbserver,Minecraft Bedrock,ubuntu-24.04
+mcv,mcvserver,Military Conflict: Vietnam,ubuntu-24.04
 mh,mhserver,MORDHAU,ubuntu-24.04
 mohaa,mohaaserver,Medal of Honor: Allied Assault,ubuntu-24.04
 mta,mtaserver,Multi Theft Auto,ubuntu-24.04

--- a/lgsm/modules/command_check_update.sh
+++ b/lgsm/modules/command_check_update.sh
@@ -30,6 +30,8 @@ elif [ "${shortname}" == "jk2" ]; then
 	update_jk2.sh
 elif [ "${shortname}" == "vints" ]; then
 	update_vints.sh
+elif [ "${shortname}" == "bb" ]; then
+	update_bb.sh
 elif [ "${shortname}" == "ut99" ]; then
 	update_ut99.sh
 elif [ "${shortname}" == "xnt" ]; then

--- a/lgsm/modules/command_update.sh
+++ b/lgsm/modules/command_update.sh
@@ -31,6 +31,8 @@ elif [ "${shortname}" == "jk2" ]; then
 	update_jk2.sh
 elif [ "${shortname}" == "vints" ]; then
 	update_vints.sh
+elif [ "${shortname}" == "bb" ]; then
+	update_bb.sh
 elif [ "${shortname}" == "ut99" ]; then
 	update_ut99.sh
 elif [ "${shortname}" == "xnt" ]; then

--- a/lgsm/modules/core_dl.sh
+++ b/lgsm/modules/core_dl.sh
@@ -139,6 +139,12 @@ fn_dl_steamcmd() {
 				fn_print_failure_nl "${commandaction} ${selfname}: ${remotelocation}: Not enough disk space to download server files"
 				fn_script_log_fail "${commandaction} ${selfname}: ${remotelocation}: Not enough disk space to download server files"
 				core_exit.sh
+			# Invalid platform for app/update request.
+			elif [ -n "$(grep -i "Invalid platform" "${steamcmdlog}" | tail -1)" ]; then
+				fn_print_failure_nl "${commandaction} ${selfname}: ${remotelocation}: Invalid platform for AppID ${appid}"
+				fn_print_nl "Check steamcmdforcewindows setting and system architecture (x86_64 required for most servers)"
+				fn_script_log_fail "${commandaction} ${selfname}: ${remotelocation}: Invalid platform for AppID ${appid}"
+				core_exit.sh
 			# Need tp purchase game.
 			elif [ -n "$(grep "No subscription" "${steamcmdlog}" | tail -1)" ]; then
 				fn_print_failure_nl "${commandaction} ${selfname}: ${remotelocation}: Steam account does not have a license for the required game"

--- a/lgsm/modules/core_modules.sh
+++ b/lgsm/modules/core_modules.sh
@@ -710,6 +710,11 @@ update_ut99.sh() {
 	fn_fetch_module
 }
 
+update_bb.sh() {
+	modulefile="${FUNCNAME[0]}"
+	fn_fetch_module
+}
+
 update_vints.sh() {
 	modulefile="${FUNCNAME[0]}"
 	fn_fetch_module

--- a/lgsm/modules/core_steamcmd.sh
+++ b/lgsm/modules/core_steamcmd.sh
@@ -428,11 +428,11 @@ fn_check_steamcmd_appmanifest() {
 		fi
 	fi
 
-	# appid 90 can occasionally report success while core HL1 files are incomplete.
-	if [ "${appid}" == "90" ]; then
+	# GoldSrc can occasionally report success while core HL1 files are incomplete.
+	if [ "${engine}" == "goldsrc" ]; then
 		if [ ! -f "${serverfiles}/hlds_run" ] || [ ! -f "${serverfiles}/engine_i486.so" ] || [ ! -d "${serverfiles}/valve" ]; then
-			fn_print_error_nl "Core HL1 files missing after appid 90 update"
-			fn_script_log_error "Core HL1 files missing after appid 90 update"
+			fn_print_error_nl "Core HL1 files missing after GoldSrc update"
+			fn_script_log_error "Core HL1 files missing after GoldSrc update"
 			fn_print_info_nl "Forcing update to correct issue"
 			fn_script_log_info "Forcing update to correct issue"
 			fn_dl_steamcmd

--- a/lgsm/modules/core_steamcmd.sh
+++ b/lgsm/modules/core_steamcmd.sh
@@ -427,4 +427,21 @@ fn_check_steamcmd_appmanifest() {
 			fn_dl_steamcmd
 		fi
 	fi
+
+	# appid 90 can occasionally report success while core HL1 files are incomplete.
+	if [ "${appid}" == "90" ]; then
+		if [ ! -f "${serverfiles}/hlds_run" ] || [ ! -f "${serverfiles}/engine_i486.so" ] || [ ! -d "${serverfiles}/valve" ]; then
+			fn_print_error_nl "Core HL1 files missing after appid 90 update"
+			fn_script_log_error "Core HL1 files missing after appid 90 update"
+			fn_print_info_nl "Forcing update to correct issue"
+			fn_script_log_info "Forcing update to correct issue"
+			fn_dl_steamcmd
+
+			if [ ! -f "${serverfiles}/hlds_run" ] || [ ! -f "${serverfiles}/engine_i486.so" ] || [ ! -d "${serverfiles}/valve" ]; then
+				fn_print_fail_nl "Core HL1 files are still missing after retry"
+				fn_script_log_fail "Core HL1 files are still missing after retry"
+				core_exit.sh
+			fi
+		fi
+	fi
 }

--- a/lgsm/modules/install_server_files.sh
+++ b/lgsm/modules/install_server_files.sh
@@ -32,14 +32,7 @@ fn_install_server_files() {
 		run="norun"
 		force="noforce"
 		md5="e3b4962cdd9d41e23c6fed65101bccde"
-	elif [ "${shortname}" == "bb" ]; then
-		remote_fileurl="http://linuxgsm.download/BrainBread/brainbread-v1.2-linuxserver.tar.xz"
-		local_filedir="${tmpdir}"
-		local_filename="brainbread-v1.2-linuxserver.tar.xz"
-		chmodx="nochmodx"
-		run="norun"
-		force="noforce"
-		md5="55f227183b736397806d5b6db6143f15"
+
 	elif [ "${shortname}" == "cod" ]; then
 		remote_fileurl="http://linuxgsm.download/CallOfDuty/cod-lnxded-1.5b-full.tar.xz"
 		local_filedir="${tmpdir}"
@@ -267,6 +260,8 @@ elif [ "${shortname}" == "jk2" ]; then
 	update_jk2.sh
 elif [ "${shortname}" == "vints" ]; then
 	update_vints.sh
+elif [ "${shortname}" == "bb" ]; then
+	update_bb.sh
 elif [ "${shortname}" == "ut99" ]; then
 	fn_install_server_files
 	update_ut99.sh

--- a/lgsm/modules/install_server_files.sh
+++ b/lgsm/modules/install_server_files.sh
@@ -269,7 +269,7 @@ elif [ "${shortname}" == "xnt" ]; then
 	update_xnt.sh
 elif [ "${shortname}" == "etl" ]; then
 	update_etl.sh
-elif [ -z "${appid}" ] || [ "${shortname}" == "ahl" ] || [ "${shortname}" == "bb" ] || [ "${shortname}" == "q4" ] || [ "${shortname}" == "ns" ] || [ "${shortname}" == "sfc" ] || [ "${shortname}" == "ts" ] || [ "${shortname}" == "vs" ] || [ "${shortname}" == "zmr" ]; then
+elif [ -z "${appid}" ] || [ "${shortname}" == "ahl" ] || [ "${shortname}" == "q4" ] || [ "${shortname}" == "ns" ] || [ "${shortname}" == "sfc" ] || [ "${shortname}" == "ts" ] || [ "${shortname}" == "vs" ] || [ "${shortname}" == "zmr" ]; then
 	if [ "${shortname}" == "ut" ]; then
 		install_eula.sh
 	fi

--- a/lgsm/modules/update_bb.sh
+++ b/lgsm/modules/update_bb.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# LinuxGSM update_bb.sh module
+# Author: Daniel Gibbs
+# Contributors: https://linuxgsm.com/contrib
+# Website: https://linuxgsm.com
+# Description: Handles updating of BrainBread servers.
+
+moduleselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+fn_update_dl() {
+	# Download and extract files to serverfiles.
+	fn_fetch_file "${remotebuildurl}" "" "" "" "${tmpdir}" "${remotebuildfilename}" "nochmodx" "norun" "force" "nohash"
+	fn_dl_extract "${tmpdir}" "${remotebuildfilename}" "${serverfiles}"
+	echo "${remotebuild}" > "${serverfiles}/build.txt"
+	fn_clear_tmp
+}
+
+fn_update_localbuild() {
+	# Gets local build info.
+	fn_print_dots "Checking local build: ${remotelocation}"
+	# Uses build file to get local build.
+	localbuild=$(head -n 1 "${serverfiles}/build.txt" 2> /dev/null)
+	if [ -z "${localbuild}" ]; then
+		fn_print_error "Checking local build: ${remotelocation}: missing local build info"
+		fn_script_log_error "Missing local build info"
+		fn_script_log_error "Set localbuild to 0"
+		localbuild="0"
+	else
+		fn_print_ok "Checking local build: ${remotelocation}"
+		fn_script_log_pass "Checking local build"
+	fi
+}
+
+fn_update_remotebuild() {
+	# Gets remote build info.
+	apiurl="https://api.github.com/repos/IronOak-Studios/BrainBread/releases/latest"
+	remotebuildresponse=$(curl -s "${apiurl}")
+	remotebuildfilename=$(echo "${remotebuildresponse}" | jq -r '.assets[] | select(.name | test("linuxserver\\.tar\\.gz$")) | .name' | head -n 1)
+	remotebuildurl=$(echo "${remotebuildresponse}" | jq -r '.assets[] | select(.name | test("linuxserver\\.tar\\.gz$")) | .browser_download_url' | head -n 1)
+	remotebuild=$(echo "${remotebuildresponse}" | jq -r '.tag_name')
+
+	if [ "${firstcommandname}" != "INSTALL" ]; then
+		fn_print_dots "Checking remote build: ${remotelocation}"
+		# Checks if remotebuild variable has been set.
+		if [ -z "${remotebuild}" ] || [ "${remotebuild}" == "null" ] || [ -z "${remotebuildurl}" ] || [ "${remotebuildurl}" == "null" ] || [ -z "${remotebuildfilename}" ] || [ "${remotebuildfilename}" == "null" ]; then
+			fn_print_fail "Checking remote build: ${remotelocation}"
+			fn_script_log_fail "Checking remote build"
+			core_exit.sh
+		else
+			fn_print_ok "Checking remote build: ${remotelocation}"
+			fn_script_log_pass "Checking remote build"
+		fi
+	else
+		# Checks if remotebuild variable has been set.
+		if [ -z "${remotebuild}" ] || [ "${remotebuild}" == "null" ] || [ -z "${remotebuildurl}" ] || [ "${remotebuildurl}" == "null" ] || [ -z "${remotebuildfilename}" ] || [ "${remotebuildfilename}" == "null" ]; then
+			fn_print_failure "Unable to get remote build"
+			fn_script_log_fail "Unable to get remote build"
+			core_exit.sh
+		fi
+	fi
+}
+
+fn_update_compare() {
+	fn_print_dots "Checking for update: ${remotelocation}"
+	# Update has been found or force update.
+	if [ "${localbuild}" != "${remotebuild}" ] || [ "${forceupdate}" == "1" ]; then
+		# Create update lockfile.
+		date '+%s' > "${lockdir:?}/update.lock"
+		fn_print_ok_nl "Checking for update: ${remotelocation}"
+		fn_print "\n"
+		fn_print_nl "${bold}${underline}Update${default} available"
+		fn_print_nl "* Local build: ${red}${localbuild}${default}"
+		fn_print_nl "* Remote build: ${green}${remotebuild}${default}"
+		if [ -n "${branch}" ]; then
+			fn_print_nl "* Branch: ${branch}"
+		fi
+		if [ -f "${rootdir}/.dev-debug" ]; then
+			fn_print_nl "Remote build info"
+			fn_print_nl "* apiurl: ${apiurl}"
+			fn_print_nl "* remotebuildfilename: ${remotebuildfilename}"
+			fn_print_nl "* remotebuildurl: ${remotebuildurl}"
+			fn_print_nl "* remotebuild: ${remotebuild}"
+		fi
+		fn_print "\n"
+		fn_script_log_info "Update available"
+		fn_script_log_info "Local build: ${localbuild}"
+		fn_script_log_info "Remote build: ${remotebuild}"
+		if [ -n "${branch}" ]; then
+			fn_script_log_info "Branch: ${branch}"
+		fi
+		fn_script_log_info "${localbuild} > ${remotebuild}"
+
+		if [ "${commandname}" == "UPDATE" ]; then
+			date +%s > "${lockdir:?}/last-updated.lock"
+			unset updateonstart
+			check_status.sh
+			# If server stopped.
+			if [ "${status}" == "0" ]; then
+				fn_update_dl
+				if [ "${localbuild}" == "0" ]; then
+					exitbypass=1
+					command_start.sh
+					fn_firstcommand_reset
+					exitbypass=1
+					fn_sleep_time_5
+					command_stop.sh
+					fn_firstcommand_reset
+				fi
+			# If server started.
+			else
+				fn_print_restart_warning
+				exitbypass=1
+				command_stop.sh
+				fn_firstcommand_reset
+				exitbypass=1
+				fn_update_dl
+				exitbypass=1
+				command_start.sh
+				fn_firstcommand_reset
+			fi
+			unset exitbypass
+			alert="update"
+		elif [ "${commandname}" == "CHECK-UPDATE" ]; then
+			alert="check-update"
+		fi
+		alert.sh
+	else
+		fn_print_ok_nl "Checking for update: ${remotelocation}"
+		fn_print "\n"
+		fn_print_nl "${bold}${underline}No update${default} available"
+		fn_print_nl "* Local build: ${green}${localbuild}${default}"
+		fn_print_nl "* Remote build: ${green}${remotebuild}${default}"
+		if [ -n "${branch}" ]; then
+			fn_print_nl "* Branch: ${branch}"
+		fi
+		fn_print "\n"
+		fn_script_log_info "No update available"
+		fn_script_log_info "Local build: ${localbuild}"
+		fn_script_log_info "Remote build: ${remotebuild}"
+		if [ -n "${branch}" ]; then
+			fn_script_log_info "Branch: ${branch}"
+		fi
+		if [ -f "${rootdir}/.dev-debug" ]; then
+			fn_print_nl "Remote build info"
+			fn_print_nl "* apiurl: ${apiurl}"
+			fn_print_nl "* remotebuildfilename: ${remotebuildfilename}"
+			fn_print_nl "* remotebuildurl: ${remotebuildurl}"
+			fn_print_nl "* remotebuild: ${remotebuild}"
+		fi
+	fi
+}
+
+# The location where the builds are checked and downloaded.
+remotelocation="github.com"
+
+if [ "${firstcommandname}" == "INSTALL" ]; then
+	fn_update_remotebuild
+	fn_update_dl
+else
+	fn_print_dots "Checking for update"
+	fn_print_dots "Checking for update: ${remotelocation}"
+	fn_script_log_info "Checking for update: ${remotelocation}"
+	fn_update_localbuild
+	fn_update_remotebuild
+	fn_update_compare
+fi

--- a/lgsm/modules/update_bb.sh
+++ b/lgsm/modules/update_bb.sh
@@ -9,7 +9,7 @@ moduleselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 fn_update_dl() {
 	# Download and extract files to serverfiles.
-	fn_fetch_file "${remotebuildurl}" "" "" "" "${tmpdir}" "${remotebuildfilename}" "nochmodx" "norun" "force" "nohash"
+	fn_fetch_file "${remotebuildurl}" "" "" "" "${tmpdir}" "${remotebuildfilename}" "nochmodx" "norun" "force" "${remotebuildhash}"
 	fn_dl_extract "${tmpdir}" "${remotebuildfilename}" "${serverfiles}"
 	echo "${remotebuild}" > "${serverfiles}/build.txt"
 	fn_clear_tmp
@@ -37,7 +37,11 @@ fn_update_remotebuild() {
 	remotebuildresponse=$(curl -s "${apiurl}")
 	remotebuildfilename=$(echo "${remotebuildresponse}" | jq -r '.assets[] | select(.name | test("linuxserver\\.tar\\.gz$")) | .name' | head -n 1)
 	remotebuildurl=$(echo "${remotebuildresponse}" | jq -r '.assets[] | select(.name | test("linuxserver\\.tar\\.gz$")) | .browser_download_url' | head -n 1)
+	remotebuildhash=$(echo "${remotebuildresponse}" | jq -r '.assets[] | select(.name | test("linuxserver\\.tar\\.gz$")) | .digest' | sed 's/^sha256://g' | head -n 1)
 	remotebuild=$(echo "${remotebuildresponse}" | jq -r '.tag_name')
+	if [ -z "${remotebuildhash}" ] || [ "${remotebuildhash}" == "null" ]; then
+		remotebuildhash="nohash"
+	fi
 
 	if [ "${firstcommandname}" != "INSTALL" ]; then
 		fn_print_dots "Checking remote build: ${remotelocation}"
@@ -79,6 +83,7 @@ fn_update_compare() {
 			fn_print_nl "* apiurl: ${apiurl}"
 			fn_print_nl "* remotebuildfilename: ${remotebuildfilename}"
 			fn_print_nl "* remotebuildurl: ${remotebuildurl}"
+			fn_print_nl "* remotebuildhash: ${remotebuildhash}"
 			fn_print_nl "* remotebuild: ${remotebuild}"
 		fi
 		fn_print "\n"
@@ -145,6 +150,7 @@ fn_update_compare() {
 			fn_print_nl "* apiurl: ${apiurl}"
 			fn_print_nl "* remotebuildfilename: ${remotebuildfilename}"
 			fn_print_nl "* remotebuildurl: ${remotebuildurl}"
+			fn_print_nl "* remotebuildhash: ${remotebuildhash}"
 			fn_print_nl "* remotebuild: ${remotebuild}"
 		fi
 	fi
@@ -157,6 +163,9 @@ if [ "${firstcommandname}" == "INSTALL" ]; then
 	fn_update_remotebuild
 	fn_update_dl
 else
+	# BrainBread requires both Steam app updates and GitHub package updates.
+	update_steamcmd.sh
+
 	fn_print_dots "Checking for update"
 	fn_print_dots "Checking for update: ${remotelocation}"
 	fn_script_log_info "Checking for update: ${remotelocation}"


### PR DESCRIPTION
Brain Bread has a new 1.3 release. This release gets it working again. This PR add an updater from github so we will always get the latest build

* Implemented `update_bb.sh` to handle updates for BrainBread servers.
* Integrated new update checks in `command_check_update.sh` and `command_update.sh`.
* Updated `install_server_files.sh` to include BrainBread server installation logic.

# Description

Please include a summary of the change and which issues are fixed.

Fixes #[issue]

## Type of change

- [ ] Bug fix (a change which fixes an issue).
- [ ] New feature (a change which adds functionality).
- [ ] New Server (new server added).
- [x] Refactor (restructures existing code).
- [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

- [ ] This pull request links to an issue.
- [x] This pull request uses the `develop` branch as its base.
- [x] This pull request subject follows the Conventional Commits standard.
- [x] This code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have checked that this code is commented where required.
- [x] I have provided a detailed enough description of this PR.
- [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

- User docs: <https://github.com/GameServerManagers/LinuxGSM-Docs>
- Dev docs: <https://github.com/GameServerManagers/LinuxGSM-Dev-Docs>

**Thank you for your Pull Request!**
