### PR TITLE
fix(vints): Update dotnet runtime

### DIFF
--- a/lgsm/data/debian-12.csv
+++ b/lgsm/data/debian-12.csv
@@ -130,7 +130,7 @@ ut2k4
 ut3
 ut99
 vh,libc6-dev,libatomic1,libpulse-dev
-vints,dotnet-runtime-8.0
+vints,dotnet-runtime-10.0
 vpmc,openjdk-17-jre
 vs
 wet

--- a/lgsm/data/debian-13.csv
+++ b/lgsm/data/debian-13.csv
@@ -130,7 +130,7 @@ ut2k4
 ut3
 ut99
 vh,libc6-dev,libatomic1,libpulse-dev
-vints,dotnet-runtime-8.0
+vints,dotnet-runtime-10.0
 vpmc,openjdk-25-jre
 vs
 wet

--- a/lgsm/data/ubuntu-24.04.csv
+++ b/lgsm/data/ubuntu-24.04.csv
@@ -130,7 +130,7 @@ ut2k4
 ut3
 ut99
 vh,libc6-dev,libatomic1,libpulse-dev
-vints,dotnet-runtime-8.0
+vints,dotnet-runtime-10.0
 vpmc,openjdk-25-jre
 vs
 wet

--- a/lgsm/data/ubuntu-26.04.csv
+++ b/lgsm/data/ubuntu-26.04.csv
@@ -130,7 +130,7 @@ ut2k4
 ut3
 ut99
 vh,libc6-dev,libatomic1,libpulse-dev
-vints,dotnet-runtime-8.0
+vints,dotnet-runtime-10.0
 vpmc,openjdk-25-jre
 vs
 wet

--- a/lgsm/modules/check_deps.sh
+++ b/lgsm/modules/check_deps.sh
@@ -8,15 +8,28 @@
 moduleselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 fn_install_dotnet_repo() {
+	local dotnetpackage
+	dotnetpackage="dotnet-runtime-7.0"
+
+	for dep in "${array_deps_missing[@]}"; do
+		if [[ "${dep}" == dotnet-runtime-* ]]; then
+			dotnetpackage="${dep}"
+			break
+		fi
+	done
+
 	if [ "${distroid}" == "ubuntu" ]; then
-		# if package dotnet-runtime-7.0 is unavailable in ubuntu repos, add the microsoft repo.
-		if ! apt-cache show dotnet-runtime-7.0 > /dev/null 2>&1; then
+		# If the required .NET package is unavailable in Ubuntu repos, add the Microsoft repo.
+		if ! apt-cache show "${dotnetpackage}" > /dev/null 2>&1; then
 			fn_fetch_file "https://packages.microsoft.com/config/ubuntu/${distroversion}/packages-microsoft-prod.deb" "" "" "" "/tmp" "packages-microsoft-prod.deb" "" "" "" ""
 			sudo dpkg -i /tmp/packages-microsoft-prod.deb
 		fi
 	elif [ "${distroid}" == "debian" ]; then
-		fn_fetch_file "https://packages.microsoft.com/config/debian/${distroversion}/packages-microsoft-prod.deb" "" "" "" "/tmp" "packages-microsoft-prod.deb" "" "" "" ""
-		sudo dpkg -i /tmp/packages-microsoft-prod.deb
+		# If the required .NET package is unavailable in Debian repos, add the Microsoft repo.
+		if ! apt-cache show "${dotnetpackage}" > /dev/null 2>&1; then
+			fn_fetch_file "https://packages.microsoft.com/config/debian/${distroversion}/packages-microsoft-prod.deb" "" "" "" "/tmp" "packages-microsoft-prod.deb" "" "" "" ""
+			sudo dpkg -i /tmp/packages-microsoft-prod.deb
+		fi
 	fi
 }
 
@@ -281,10 +294,10 @@ fn_deps_detector() {
 			depstatus=1
 			monoinstalled=false
 		fi
-	# .NET Core: A .NET Core repo needs to be installed.
-	elif [ "${deptocheck}" == "dotnet-runtime-7.0" ]; then
-		# .NET is not installed.
-		if dotnet --list-runtimes | grep -q "Microsoft.NETCore.App 7.0"; then
+	# .NET runtime: check installed runtime version for any dotnet-runtime-X.Y package.
+	elif [[ "${deptocheck}" =~ ^dotnet-runtime-([0-9]+\.[0-9]+)$ ]]; then
+		dotnetrequired="${BASH_REMATCH[1]}"
+		if [ "$(command -v dotnet 2> /dev/null)" ] && dotnet --list-runtimes | grep -q "Microsoft.NETCore.App ${dotnetrequired}"; then
 			depstatus=0
 			dotnetinstalled=true
 		else
@@ -376,6 +389,15 @@ if { [ "${distroid}" == "ubuntu" ] && dpkg --compare-versions "${distroversion}"
 		fn_print_failure_nl "${gamename} is not supported on ${distroname} (requires Ubuntu <= 20.04 or Debian <= 11)."
 		fn_script_log_fail "${gamename} is not supported on ${distroname}."
 		core_exit.sh
+	fi
+fi
+
+# Vintage Story tracks newer .NET runtimes; older distro releases may not ship required packages.
+if [ "${shortname}" == "vints" ]; then
+	if { [ "${distroid}" == "ubuntu" ] && dpkg --compare-versions "${distroversion}" "lt" "24.04"; } || { [ "${distroid}" == "debian" ] && dpkg --compare-versions "${distroversion}" "lt" "12"; } || [ "${distroid}" == "centos" ] || [ "${distroid}" == "rhel" ] || [ "${distroid}" == "rocky" ] || [ "${distroid}" == "almalinux" ]; then
+		fn_print_warning_nl "${gamename} may require newer .NET runtimes than ${distroname} provides."
+		echo -e "If startup fails due to missing .NET runtime, upgrading to Ubuntu 24.04+ or Debian 12+ is recommended."
+		fn_script_log_warn "${gamename} may require newer .NET runtimes than ${distroname} provides."
 	fi
 fi
 


### PR DESCRIPTION
# Description

Fixes #4818
Related #4732
Related #4285 (historical context)

This PR fixes Vintage Story dependency handling when required .NET runtime versions change.

- Updates dependency detection in check_deps.sh to support versioned packages in the form dotnet-runtime-X.Y (instead of a hardcoded dotnet-runtime-7.0).
- Keeps Microsoft repo bootstrap logic, but makes it package-aware so it checks the actual required .NET package before adding the repo.
- Updates Vintage Story distro dependency mapping so dotnet-runtime-10.0 is used only on distro tracks where it is available, while older tracks remain on dotnet-runtime-8.0.
- Adds a non-blocking Vintage Story warning encouraging users on older distros to upgrade when runtime availability is limited.

## Type of change

- [x] Bug fix (a change which fixes an issue).
- [ ] New feature (a change which adds functionality).
- [ ] New Server (new server added).
- [ ] Refactor (restructures existing code).
- [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

- [x] This pull request links to an issue.
- [x] This pull request uses the develop branch as its base.
- [x] This pull request subject follows the Conventional Commits standard.
- [x] This code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have checked that this code is commented where required.
- [x] I have provided a detailed enough description of this PR.
- [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

No documentation updates are required for this change.

- User docs: <https://github.com/GameServerManagers/LinuxGSM-Docs>
- Dev docs: <https://github.com/GameServerManagers/LinuxGSM-Dev-Docs>

**Thank you for your Pull Request!**
