### PR TITLE
fix: Update Debian 13 dependencies and add to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,11 +30,18 @@ body:
       label: Linux distro
       multiple: true
       options:
+        - Ubuntu 26.04
         - Ubuntu 24.04
         - Ubuntu 22.04
         - Ubuntu 20.04
+        - Debian 13
         - Debian 12
         - Debian 11
+        - AlmaLinux 9
+        - AlmaLinux 8
+        - Rocky 10
+        - Rocky 9
+        - Rocky 8
         - RedHat 9
         - RedHat 8
         - Other

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -30,11 +30,18 @@ body:
       label: Linux distro
       multiple: true
       options:
+        - Ubuntu 26.04
         - Ubuntu 24.04
         - Ubuntu 22.04
         - Ubuntu 20.04
+        - Debian 13
         - Debian 12
         - Debian 11
+        - AlmaLinux 9
+        - AlmaLinux 8
+        - Rocky 10
+        - Rocky 9
+        - Rocky 8
         - RedHat 9
         - RedHat 8
         - Other

--- a/lgsm/data/debian-13.csv
+++ b/lgsm/data/debian-13.csv
@@ -16,7 +16,7 @@ bfv,libncurses5:i386,libstdc++5:i386
 bmdm,libncurses5:i386
 bo
 bs
-bt,libicu-dev,dos2unix,libxml2-utils
+bt,libicu-dev,dos2unix,libxml2
 btl
 cc
 ck,xvfb,libxi6
@@ -71,7 +71,7 @@ mcb
 mcv
 mh
 mohaa,libstdc++5:i386
-mta,libncursesw5,libxml2-utils
+mta,libncursesw6,libxml2
 nd
 nec
 nmrih
@@ -104,14 +104,14 @@ sb
 sbots
 scpsl,mono-complete,libicu76
 scpslsm,mono-complete
-sdtd,telnet,expect,libxml2-utils
+sdtd,telnet,expect,libxml2
 sf
 sfc
 sm,telnet,expect
 sof2
 sol
 squad
-st,libxml2-utils
+st,libxml2
 stn
 sven,libssl3:i386,zlib1g:i386
 terraria


### PR DESCRIPTION
# Description

Fixes #4847

Updates Debian 13 dependencies and adds Debian 13 to issue templates.

## Type of change

- [x] Bug fix (a change which fixes an issue).

## Checklist

- [x] This pull request links to an issue.
- [x] This pull request uses the `master` branch as its base.
- [x] This pull request subject follows the Conventional Commits standard.
- [x] This code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have provided a detailed enough description of this PR.

## Details

### Dependency Updates (`lgsm/data/debian-13.csv`)
- Replace `libncursesw5` with `libncursesw6` (removed from Debian 13)
- Replace `libxml2-utils` with `libxml2` (removed from Debian 13)
- Affects: Multi Theft Auto (mta), Battle Tanks (bt), Soldat Dedicated (sdtd), Synergy (st)

### Issue Templates
- Add Debian 13 to bug_report.yml distro options
- Add Debian 13 to feature_request.yml distro options
- Allows users to properly report issues on Debian 13