### PR TITLE
fix: Correct CSV file path in update-lgsm command

### DIFF
--- a/lgsm/modules/command_update_linuxgsm.sh
+++ b/lgsm/modules/command_update_linuxgsm.sh
@@ -188,7 +188,7 @@ if [ -f "${datadir}/${distroid}-${distroversioncsv}.csv" ]; then
 		fn_print_update_eol_nl
 		fn_script_log "Checking ${remotereponame} ${distroid}-${distroversioncsv}.csv"
 		rm -f "${datadir:?}/${distroid}-${distroversioncsv}.csv"
-		fn_fetch_file_github "${datadir}" "${distroid}-${distroversioncsv}.csv" "${datadir}" "nochmodx" "norun" "noforce" "nohash"
+		fn_fetch_file_github "lgsm/data" "${distroid}-${distroversioncsv}.csv" "${datadir}" "nochmodx" "norun" "noforce" "nohash"
 	else
 		fn_print_skip_eol_nl
 		fn_script_log_pass "Checking ${remotereponame} ${distroid}-${distroversioncsv}.csv"


### PR DESCRIPTION
# Description

Fixes #4856 - Corrects malformed GitHub URLs when fetching distro CSV files during update-lgsm.

## Type of change

- [x] Bug fix (a change which fixes an issue).

## Checklist

- [x] This pull request links to an issue.
- [x] This pull request uses the `master` branch as its base.
- [x] This pull request subject follows the Conventional Commits standard.
- [x] This code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have provided a detailed enough description of this PR.

## Problem

When running `update-lgsm` for the first time, the command fails to download distro CSV files with a 404 error:

```
ERROR: https://raw.githubusercontent.com/GameServerManagers/LinuxGSM/master//home/cs2server/lgsm/data/debian-12.csv
```

The URL contains a double slash and an absolute path, making it malformed. Running `update-lgsm` a second time would succeed because the CSV file was already cached locally.

## Solution

Changed the first parameter to `fn_fetch_file_github` from the absolute path `"${datadir}"` to the repository-relative path `"lgsm/data"`. This matches the correct usage pattern elsewhere in the code (e.g., for config files at line 157).

## Files Changed

- `lgsm/modules/command_update_linuxgsm.sh` - Line 191: Changed repository path parameter